### PR TITLE
feat(exception-handling): implement global and custom exception handling (#96)

### DIFF
--- a/.idea/checkstyle-idea.xml
+++ b/.idea/checkstyle-idea.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CheckStyle-IDEA" serialisationVersion="2">
+    <checkstyleVersion>10.21.3</checkstyleVersion>
+    <scanScope>JavaOnly</scanScope>
+    <option name="thirdPartyClasspath" />
+    <option name="activeLocationIds" />
+    <option name="locations">
+      <list>
+        <ConfigurationLocation id="bundled-sun-checks" type="BUNDLED" scope="All" description="Sun Checks">(bundled)</ConfigurationLocation>
+        <ConfigurationLocation id="bundled-google-checks" type="BUNDLED" scope="All" description="Google Checks">(bundled)</ConfigurationLocation>
+      </list>
+    </option>
+  </component>
+</project>

--- a/apps/user-service/src/main/java/com/bytebandit/userservice/enums/ErrorCode.java
+++ b/apps/user-service/src/main/java/com/bytebandit/userservice/enums/ErrorCode.java
@@ -1,0 +1,55 @@
+package com.bytebandit.userservice.enums;
+
+
+import lombok.Getter;
+
+@Getter
+public enum ErrorCode {
+
+    // Authentication & Authorization Errors
+    AUTH_INVALID_CREDENTIALS("AUTH-01", "Invalid credentials provided."),
+    AUTH_TOKEN_EXPIRED("AUTH-02", "Authentication token has expired."),
+    AUTH_ACCESS_DENIED("AUTH-03", "Access denied for the requested resource."),
+
+    // User Errors
+    USER_NOT_FOUND("USER-01", "User not found."),
+    USER_ALREADY_EXISTS("USER-02", "User already exists."),
+    USER_INVALID_INPUT("USER-03", "Invalid user input provided."),
+    EMAIL_ALREADY_USED("USER-04", "Email is already in use."),
+
+    // Image Upload Errors
+    IMAGE_UPLOAD_FAILED("IMG-01", "Image upload failed."),
+    INVALID_IMAGE_FORMAT("IMG-02", "Invalid image format."),
+
+    // Password & Security Errors
+    INVALID_PASSWORD("SEC-01", "Invalid password provided."),
+    TOKEN_INVALID("SEC-02", "Invalid authentication token."),
+    REFRESH_TOKEN_EXPIRED("SEC-03", "Refresh token has expired."),
+
+    // API Rate Limit Errors
+    TOO_MANY_REQUESTS("API-01", "Too many requests. Please try again later."),
+
+    // General Validation Errors
+    INVALID_INPUT_FORMAT("VALID-01", "Invalid input format."),
+    REQUEST_VALIDATION_FAILED("VALID-02", "Request validation failed."),
+
+    // System Errors
+    INTERNAL_SERVER_ERROR("SYS-01", "An internal server error occurred."),
+    SERVICE_UNAVAILABLE("SYS-02", "The service is temporarily unavailable."),
+
+    // Unknown Error
+    UNKNOWN_ERROR("UNKNOWN", "An unknown error has occurred.");
+
+    private final String code;
+    private final String message;
+
+    ErrorCode(String code, String message) {
+        this.code = code;
+        this.message = message;
+    }
+
+    @Override
+    public String toString() {
+        return code + ": " + message;
+    }
+}

--- a/apps/user-service/src/main/java/com/bytebandit/userservice/enums/ErrorCode.java
+++ b/apps/user-service/src/main/java/com/bytebandit/userservice/enums/ErrorCode.java
@@ -36,6 +36,8 @@ public enum ErrorCode {
     // System Errors
     INTERNAL_SERVER_ERROR("SYS-01", "An internal server error occurred."),
     SERVICE_UNAVAILABLE("SYS-02", "The service is temporarily unavailable."),
+    // Database Errors
+    DB_CONSTRAINT_VIOLATION("DB-01", "Database constraint violation."),
 
     // Unknown Error
     UNKNOWN_ERROR("UNKNOWN", "An unknown error has occurred.");

--- a/apps/user-service/src/main/java/com/bytebandit/userservice/enums/PasswordValidationError.java
+++ b/apps/user-service/src/main/java/com/bytebandit/userservice/enums/PasswordValidationError.java
@@ -1,11 +1,21 @@
 package com.bytebandit.userservice.enums;
-
+/**
+ * Enumeration of possible password validation errors.
+ * Used to provide specific feedback when password validation fails.
+ */
 public enum PasswordValidationError {
+    /** Password does not meet length requirements */
     LENGTH_ERROR,
+    /** Password is missing an uppercase letter */
     MISSING_UPPERCASE,
+    /** Password is missing a lowercase letter */
     MISSING_LOWERCASE,
+    /** Password is missing a digit */
     MISSING_DIGIT,
+    /** Password is missing a special character */
     MISSING_SPECIAL_CHAR,
+    /** Password contains the username */
     CONTAINS_USERNAME,
+    /** Password is a common or easily guessable password */
     COMMON_PASSWORD
 }

--- a/apps/user-service/src/main/java/com/bytebandit/userservice/enums/PasswordValidationError.java
+++ b/apps/user-service/src/main/java/com/bytebandit/userservice/enums/PasswordValidationError.java
@@ -1,0 +1,11 @@
+package com.bytebandit.userservice.enums;
+
+public enum PasswordValidationError {
+    LENGTH_ERROR,
+    MISSING_UPPERCASE,
+    MISSING_LOWERCASE,
+    MISSING_DIGIT,
+    MISSING_SPECIAL_CHAR,
+    CONTAINS_USERNAME,
+    COMMON_PASSWORD
+}

--- a/apps/user-service/src/main/java/com/bytebandit/userservice/exception/EmailAlreadyUsedException.java
+++ b/apps/user-service/src/main/java/com/bytebandit/userservice/exception/EmailAlreadyUsedException.java
@@ -1,0 +1,7 @@
+package com.bytebandit.userservice.exception;
+
+public class EmailAlreadyUsedException extends RuntimeException {
+    public EmailAlreadyUsedException(String message) {
+        super(message);
+    }
+}

--- a/apps/user-service/src/main/java/com/bytebandit/userservice/exception/GlobalExceptionHandler.java
+++ b/apps/user-service/src/main/java/com/bytebandit/userservice/exception/GlobalExceptionHandler.java
@@ -1,0 +1,85 @@
+package com.bytebandit.userservice.exception;
+
+import com.bytebandit.userservice.enums.ErrorCode;
+import com.bytebandit.userservice.response.ErrorResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.web.HttpMediaTypeNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.dao.DataIntegrityViolationException;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(UserAlreadyExistsException.class)
+    public ResponseEntity<ErrorResponse> handleUserAlreadyExists(UserAlreadyExistsException ex, HttpServletRequest request) {
+        return buildResponse(HttpStatus.CONFLICT, ErrorCode.USER_ALREADY_EXISTS, request, ex.getMessage());
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleValidationException(MethodArgumentNotValidException ex, HttpServletRequest request) {
+        String details = ex.getBindingResult().getFieldErrors()
+                .stream()
+                .map(error -> error.getField() + ": " + error.getDefaultMessage())
+                .findFirst()
+                .orElse("Validation error");
+
+        return buildResponse(HttpStatus.BAD_REQUEST, ErrorCode.REQUEST_VALIDATION_FAILED,  request, details);
+    }
+
+    @ExceptionHandler(UserNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleUserNotFound(UserNotFoundException ex, HttpServletRequest request) {
+        return buildResponse(HttpStatus.NOT_FOUND, ErrorCode.USER_NOT_FOUND, request, ex.getMessage());
+    }
+
+    @ExceptionHandler(BadCredentialsException.class)
+    public ResponseEntity<ErrorResponse> handleBadCredentials(BadCredentialsException ex, HttpServletRequest request) {
+        return buildResponse(HttpStatus.UNAUTHORIZED, ErrorCode.AUTH_INVALID_CREDENTIALS, request, ex.getMessage());
+    }
+
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ResponseEntity<ErrorResponse> handleDataIntegrityViolation(DataIntegrityViolationException ex, HttpServletRequest request) {
+        return buildResponse(HttpStatus.CONFLICT, ErrorCode.INTERNAL_SERVER_ERROR,  request, ex.getMostSpecificCause().getMessage());
+    }
+
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<ErrorResponse> handleMissingParameter(MissingServletRequestParameterException ex, HttpServletRequest request) {
+        return buildResponse(HttpStatus.BAD_REQUEST, ErrorCode.INVALID_INPUT_FORMAT,  request, "Missing parameter: " + ex.getParameterName());
+    }
+
+    @ExceptionHandler(HttpMediaTypeNotSupportedException.class)
+    public ResponseEntity<ErrorResponse> handleUnsupportedMediaType(HttpMediaTypeNotSupportedException ex, HttpServletRequest request) {
+        return buildResponse(HttpStatus.UNSUPPORTED_MEDIA_TYPE, ErrorCode.INVALID_IMAGE_FORMAT, request, "Provided media type: " + ex.getContentType());
+    }
+
+    @ExceptionHandler(RefreshTokenExpiredException.class)
+    public ResponseEntity<ErrorResponse> handleRefreshTokenExpired(RefreshTokenExpiredException ex, HttpServletRequest request) {
+        return buildResponse(HttpStatus.UNAUTHORIZED, ErrorCode.REFRESH_TOKEN_EXPIRED, request, ex.getMessage());
+    }
+
+    @ExceptionHandler(TooManyRequestsException.class)
+    public ResponseEntity<ErrorResponse> handleTooManyRequests(TooManyRequestsException ex, HttpServletRequest request) {
+        return buildResponse(HttpStatus.TOO_MANY_REQUESTS, ErrorCode.TOO_MANY_REQUESTS,  request, ex.getMessage());
+    }
+
+    @ExceptionHandler(InvalidImageFormatException.class)
+    public ResponseEntity<ErrorResponse> handleInvalidImageFormat(InvalidImageFormatException ex, HttpServletRequest request) {
+        return buildResponse(HttpStatus.UNSUPPORTED_MEDIA_TYPE, ErrorCode.INVALID_IMAGE_FORMAT,  request, ex.getMessage());
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleGlobalException(Exception ex, HttpServletRequest request) {
+        return buildResponse(HttpStatus.INTERNAL_SERVER_ERROR, ErrorCode.UNKNOWN_ERROR,  request, ex.getMessage());
+    }
+
+    private ResponseEntity<ErrorResponse> buildResponse(HttpStatus status, ErrorCode errorCode, HttpServletRequest request, String details) {
+        return ResponseEntity.status(status).body(
+                ErrorResponse.create(status, status.getReasonPhrase(), errorCode.getMessage(), errorCode.getCode(), details, request.getRequestURI())
+        );
+    }
+}

--- a/apps/user-service/src/main/java/com/bytebandit/userservice/exception/GlobalExceptionHandler.java
+++ b/apps/user-service/src/main/java/com/bytebandit/userservice/exception/GlobalExceptionHandler.java
@@ -13,6 +13,9 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.dao.DataIntegrityViolationException;
 
+import java.util.UUID;
+import java.util.stream.Collectors;
+
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
@@ -26,10 +29,9 @@ public class GlobalExceptionHandler {
         String details = ex.getBindingResult().getFieldErrors()
                 .stream()
                 .map(error -> error.getField() + ": " + error.getDefaultMessage())
-                .findFirst()
-                .orElse("Validation error");
+                .collect(Collectors.joining(", "));
 
-        return buildResponse(HttpStatus.BAD_REQUEST, ErrorCode.REQUEST_VALIDATION_FAILED,  request, details);
+        return buildResponse(HttpStatus.BAD_REQUEST, ErrorCode.REQUEST_VALIDATION_FAILED, request, details);
     }
 
     @ExceptionHandler(UserNotFoundException.class)
@@ -79,7 +81,7 @@ public class GlobalExceptionHandler {
 
     private ResponseEntity<ErrorResponse> buildResponse(HttpStatus status, ErrorCode errorCode, HttpServletRequest request, String details) {
         return ResponseEntity.status(status).body(
-                ErrorResponse.create(status, status.getReasonPhrase(), errorCode.getMessage(), errorCode.getCode(), details, request.getRequestURI())
+                ErrorResponse.create(status, status.getReasonPhrase(), errorCode.getMessage(), errorCode.getCode(), details, request.getRequestURI(), UUID::randomUUID)
         );
     }
 }

--- a/apps/user-service/src/main/java/com/bytebandit/userservice/exception/GlobalExceptionHandler.java
+++ b/apps/user-service/src/main/java/com/bytebandit/userservice/exception/GlobalExceptionHandler.java
@@ -44,7 +44,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(DataIntegrityViolationException.class)
     public ResponseEntity<ErrorResponse> handleDataIntegrityViolation(DataIntegrityViolationException ex, HttpServletRequest request) {
-        return buildResponse(HttpStatus.CONFLICT, ErrorCode.INTERNAL_SERVER_ERROR,  request, ex.getMostSpecificCause().getMessage());
+                return buildResponse(HttpStatus.CONFLICT, ErrorCode.USER_INVALID_INPUT, request, ex.getMostSpecificCause().getMessage());
     }
 
     @ExceptionHandler(MissingServletRequestParameterException.class)

--- a/apps/user-service/src/main/java/com/bytebandit/userservice/exception/ImageUploadException.java
+++ b/apps/user-service/src/main/java/com/bytebandit/userservice/exception/ImageUploadException.java
@@ -1,0 +1,7 @@
+package com.bytebandit.userservice.exception;
+
+public class ImageUploadException extends RuntimeException {
+    public ImageUploadException(String message) {
+        super(message);
+    }
+}

--- a/apps/user-service/src/main/java/com/bytebandit/userservice/exception/InvalidImageFormatException.java
+++ b/apps/user-service/src/main/java/com/bytebandit/userservice/exception/InvalidImageFormatException.java
@@ -1,6 +1,4 @@
 package com.bytebandit.userservice.exception;
-
-
 public class InvalidImageFormatException extends RuntimeException {
     public InvalidImageFormatException(String message) {
         super(message);

--- a/apps/user-service/src/main/java/com/bytebandit/userservice/exception/InvalidImageFormatException.java
+++ b/apps/user-service/src/main/java/com/bytebandit/userservice/exception/InvalidImageFormatException.java
@@ -1,0 +1,8 @@
+package com.bytebandit.userservice.exception;
+
+
+public class InvalidImageFormatException extends RuntimeException {
+    public InvalidImageFormatException(String message) {
+        super(message);
+    }
+}

--- a/apps/user-service/src/main/java/com/bytebandit/userservice/exception/InvalidImageFormatException.java
+++ b/apps/user-service/src/main/java/com/bytebandit/userservice/exception/InvalidImageFormatException.java
@@ -1,6 +1,23 @@
 package com.bytebandit.userservice.exception;
+
+import java.io.Serial;
+
+/**
+ * Exception thrown when image format validation fails.
+ * This exception is handled by GlobalExceptionHandler.
+ */
 public class InvalidImageFormatException extends RuntimeException {
+    @Serial
+    private static final long serialVersionUID = 1L;
     public InvalidImageFormatException(String message) {
         super(message);
+    }
+
+    public InvalidImageFormatException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public InvalidImageFormatException(Throwable cause) {
+        super(cause);
     }
 }

--- a/apps/user-service/src/main/java/com/bytebandit/userservice/exception/InvalidPasswordException.java
+++ b/apps/user-service/src/main/java/com/bytebandit/userservice/exception/InvalidPasswordException.java
@@ -1,7 +1,30 @@
 package com.bytebandit.userservice.exception;
 
+import com.bytebandit.userservice.enums.PasswordValidationError;
+import lombok.Getter;
+
+/**
+ * + * EXCEPTION THROWN WHEN PASSWORD VALIDATION FAILS.
+ * + * EXAMPLES: PASSWORD TOO SHORT, MISSING REQUIRED CHARACTERS, ETC.
+ * +
+ */
+@Getter
 public class InvalidPasswordException extends RuntimeException {
+    private final PasswordValidationError validationError;
+
+
     public InvalidPasswordException(String message) {
-        super(message);
+        this(message, null, null);
     }
+
+    public InvalidPasswordException(String message, PasswordValidationError validationError) {
+        super(message);
+        this.validationError = validationError;
+    }
+
+    public InvalidPasswordException(String message, Throwable cause, PasswordValidationError validationError) {
+        super(message, cause);
+        this.validationError = validationError;
+    }
+
 }

--- a/apps/user-service/src/main/java/com/bytebandit/userservice/exception/InvalidPasswordException.java
+++ b/apps/user-service/src/main/java/com/bytebandit/userservice/exception/InvalidPasswordException.java
@@ -1,0 +1,7 @@
+package com.bytebandit.userservice.exception;
+
+public class InvalidPasswordException extends RuntimeException {
+    public InvalidPasswordException(String message) {
+        super(message);
+    }
+}

--- a/apps/user-service/src/main/java/com/bytebandit/userservice/exception/InvalidPasswordException.java
+++ b/apps/user-service/src/main/java/com/bytebandit/userservice/exception/InvalidPasswordException.java
@@ -4,9 +4,9 @@ import com.bytebandit.userservice.enums.PasswordValidationError;
 import lombok.Getter;
 
 /**
- * + * EXCEPTION THROWN WHEN PASSWORD VALIDATION FAILS.
- * + * EXAMPLES: PASSWORD TOO SHORT, MISSING REQUIRED CHARACTERS, ETC.
- * +
+ * * EXCEPTION THROWN WHEN PASSWORD VALIDATION FAILS.
+ * * EXAMPLES: PASSWORD TOO SHORT, MISSING REQUIRED CHARACTERS, ETC.
+ *
  */
 @Getter
 public class InvalidPasswordException extends RuntimeException {

--- a/apps/user-service/src/main/java/com/bytebandit/userservice/exception/InvalidTokenException.java
+++ b/apps/user-service/src/main/java/com/bytebandit/userservice/exception/InvalidTokenException.java
@@ -1,0 +1,9 @@
+package com.bytebandit.userservice.exception;
+
+
+public class InvalidTokenException extends RuntimeException {
+    public InvalidTokenException(String message) {
+        super(message);
+    }
+}
+

--- a/apps/user-service/src/main/java/com/bytebandit/userservice/exception/InvalidTokenException.java
+++ b/apps/user-service/src/main/java/com/bytebandit/userservice/exception/InvalidTokenException.java
@@ -1,9 +1,22 @@
 package com.bytebandit.userservice.exception;
-
-
+import java.io.Serial;
+/**
+ + * Exception thrown when a provided token is invalid, expired, or cannot be validated.
+ + * Used primarily in authentication and authorization processes.
+ + */
 public class InvalidTokenException extends RuntimeException {
+    @Serial
+    private static final long serialVersionUID = 1L;
+
     public InvalidTokenException(String message) {
         super(message);
+    }
+
+    public InvalidTokenException(String message, Throwable cause) {
+        super(message, cause);
+    }
+    public InvalidTokenException(Throwable cause) {
+        super(cause);
     }
 }
 

--- a/apps/user-service/src/main/java/com/bytebandit/userservice/exception/InvalidUserInputException.java
+++ b/apps/user-service/src/main/java/com/bytebandit/userservice/exception/InvalidUserInputException.java
@@ -1,7 +1,14 @@
 package com.bytebandit.userservice.exception;
 
+/**
+ * Exception thrown when user input validation fails.
+ * This exception is caught by the GlobalExceptionHandler to return appropriate error responses.
+ */
 public class InvalidUserInputException extends RuntimeException {
     public InvalidUserInputException(String message) {
         super(message);
+    }
+    public InvalidUserInputException(String message, Throwable cause) {
+        super(message, cause);
     }
 }

--- a/apps/user-service/src/main/java/com/bytebandit/userservice/exception/InvalidUserInputException.java
+++ b/apps/user-service/src/main/java/com/bytebandit/userservice/exception/InvalidUserInputException.java
@@ -1,0 +1,7 @@
+package com.bytebandit.userservice.exception;
+
+public class InvalidUserInputException extends RuntimeException {
+    public InvalidUserInputException(String message) {
+        super(message);
+    }
+}

--- a/apps/user-service/src/main/java/com/bytebandit/userservice/exception/InvalidUserInputException.java
+++ b/apps/user-service/src/main/java/com/bytebandit/userservice/exception/InvalidUserInputException.java
@@ -1,10 +1,14 @@
 package com.bytebandit.userservice.exception;
 
+import java.io.Serial;
+
 /**
  * Exception thrown when user input validation fails.
  * This exception is caught by the GlobalExceptionHandler to return appropriate error responses.
  */
 public class InvalidUserInputException extends RuntimeException {
+    @Serial
+    private static final long serialVersionUID = 1L;
     public InvalidUserInputException(String message) {
         super(message);
     }

--- a/apps/user-service/src/main/java/com/bytebandit/userservice/exception/RefreshTokenExpiredException.java
+++ b/apps/user-service/src/main/java/com/bytebandit/userservice/exception/RefreshTokenExpiredException.java
@@ -1,0 +1,8 @@
+package com.bytebandit.userservice.exception;
+
+public class RefreshTokenExpiredException extends RuntimeException {
+    public RefreshTokenExpiredException(String message) {
+        super(message);
+    }
+}
+

--- a/apps/user-service/src/main/java/com/bytebandit/userservice/exception/TooManyRequestsException.java
+++ b/apps/user-service/src/main/java/com/bytebandit/userservice/exception/TooManyRequestsException.java
@@ -1,0 +1,8 @@
+package com.bytebandit.userservice.exception;
+
+public class TooManyRequestsException extends RuntimeException {
+    public TooManyRequestsException(String message) {
+        super(message);
+    }
+}
+

--- a/apps/user-service/src/main/java/com/bytebandit/userservice/exception/UnauthorizedAccessException.java
+++ b/apps/user-service/src/main/java/com/bytebandit/userservice/exception/UnauthorizedAccessException.java
@@ -1,0 +1,8 @@
+package com.bytebandit.userservice.exception;
+
+public class UnauthorizedAccessException extends RuntimeException {
+    public UnauthorizedAccessException(String message) {
+        super(message);
+    }
+}
+

--- a/apps/user-service/src/main/java/com/bytebandit/userservice/exception/UserNotFoundException.java
+++ b/apps/user-service/src/main/java/com/bytebandit/userservice/exception/UserNotFoundException.java
@@ -1,0 +1,7 @@
+package com.bytebandit.userservice.exception;
+
+public class UserNotFoundException extends RuntimeException {
+    public UserNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/apps/user-service/src/main/java/com/bytebandit/userservice/response/ApiResponse.java
+++ b/apps/user-service/src/main/java/com/bytebandit/userservice/response/ApiResponse.java
@@ -1,0 +1,18 @@
+package com.bytebandit.userservice.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ApiResponse {
+    private int status;
+    private String message;
+    private Object data;
+    private String timestamp;
+    private String path;
+}

--- a/apps/user-service/src/main/java/com/bytebandit/userservice/response/ApiResponse.java
+++ b/apps/user-service/src/main/java/com/bytebandit/userservice/response/ApiResponse.java
@@ -5,6 +5,14 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+/**
+ * Standardized API response structure.
+ * status HTTP status code
+ * message Response message
+ * data Payload container
+ * timestamp Response generation time
+ * path Request URI path
+ */
 @Data
 @AllArgsConstructor
 @NoArgsConstructor

--- a/apps/user-service/src/main/java/com/bytebandit/userservice/response/ErrorResponse.java
+++ b/apps/user-service/src/main/java/com/bytebandit/userservice/response/ErrorResponse.java
@@ -7,7 +7,11 @@ import org.springframework.http.HttpStatus;
 import java.time.Instant;
 import java.util.UUID;
 import java.util.function.Supplier;
-
+/**
+ + * Standardized error response format for API errors.
+ + * Used by GlobalExceptionHandler to create consistent error responses across the application.
+ + * Includes unique error ID, timestamp, HTTP status, error details and path information.
+ + */
 @Value
 @Builder
 public class ErrorResponse {

--- a/apps/user-service/src/main/java/com/bytebandit/userservice/response/ErrorResponse.java
+++ b/apps/user-service/src/main/java/com/bytebandit/userservice/response/ErrorResponse.java
@@ -6,6 +6,7 @@ import org.springframework.http.HttpStatus;
 
 import java.time.Instant;
 import java.util.UUID;
+import java.util.function.Supplier;
 
 @Value
 @Builder
@@ -19,9 +20,9 @@ public class ErrorResponse {
     String details;
     String path;
 
-    public static ErrorResponse create(HttpStatus status, String error, String message, String errorCode, String details, String path) {
+    public static ErrorResponse create(HttpStatus status, String error, String message, String errorCode, String details, String path, Supplier<UUID> uuidSupplier) {
         return ErrorResponse.builder()
-                .errorId(UUID.randomUUID().toString())
+                .errorId(uuidSupplier.get().toString())
                 .timestamp(Instant.now())
                 .status(status.value())
                 .error(error)

--- a/apps/user-service/src/main/java/com/bytebandit/userservice/response/ErrorResponse.java
+++ b/apps/user-service/src/main/java/com/bytebandit/userservice/response/ErrorResponse.java
@@ -1,13 +1,10 @@
 package com.bytebandit.userservice.response;
 
 import lombok.Builder;
-import lombok.Getter;
-import lombok.Singular;
 import lombok.Value;
 import org.springframework.http.HttpStatus;
 
 import java.time.Instant;
-import java.util.List;
 import java.util.UUID;
 
 @Value

--- a/apps/user-service/src/main/java/com/bytebandit/userservice/response/ErrorResponse.java
+++ b/apps/user-service/src/main/java/com/bytebandit/userservice/response/ErrorResponse.java
@@ -1,0 +1,37 @@
+package com.bytebandit.userservice.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Singular;
+import lombok.Value;
+import org.springframework.http.HttpStatus;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+@Value
+@Builder
+public class ErrorResponse {
+    String errorId;
+    Instant timestamp;
+    int status;
+    String error;
+    String message;
+    String errorCode;
+    String details;
+    String path;
+
+    public static ErrorResponse create(HttpStatus status, String error, String message, String errorCode, String details, String path) {
+        return ErrorResponse.builder()
+                .errorId(UUID.randomUUID().toString())
+                .timestamp(Instant.now())
+                .status(status.value())
+                .error(error)
+                .message(message)
+                .errorCode(errorCode)
+                .details(details)
+                .path(path)
+                .build();
+    }
+}


### PR DESCRIPTION
## **Title:** feat: Implement global and custom exception handling (#96)

### **Description**  
This PR introduces a centralized exception-handling mechanism, improving error management and API consistency. It also adds an `ErrorCode` enum to standardize error messages for better front-end integration.  

### **Related Issue**  
Closes #96  

### **Type of Change**  
- [x] New feature  
- [ ] Documentation update  

### **Checklist**  
- [x] I have tested my changes.  

### **Screenshots/Videos (if applicable)**  
![Screenshot from 2025-03-20 03-33-06](https://github.com/user-attachments/assets/55815e5a-c982-4361-910c-b3f75783f8e2)
![Screenshot from 2025-03-20 03-25-00](https://github.com/user-attachments/assets/af86e75c-6465-4762-b908-79d119de3842)
![Screenshot from 2025-03-20 03-21-58](https://github.com/user-attachments/assets/228a14ed-f6a1-4b9d-83e8-7a07a984d5e2)
![Screenshot from 2025-03-20 04-19-48](https://github.com/user-attachments/assets/ed63d711-25ff-4a37-9457-683e46f3e898)


### **Additional Context**  
- **Added `GlobalExceptionHandler`** for centralized exception management.  
- **Created custom exceptions**: `EmailAlreadyUsedException`, `UserNotFoundException`, `UnauthorizedAccessException`, etc.  
- **Standardized API error responses** using `ApiResponse` and `ErrorResponse`.  
- **Introduced `ErrorCode` enum** to enable the front end to interpret error messages easily.  
- **Enhanced logging** for better debugging.  
