### PR TITLE
Add a script to build docker image easily

### DIFF
--- a/apps/backend/config-server/pom.xml
+++ b/apps/backend/config-server/pom.xml
@@ -8,7 +8,6 @@
         <version>0.0.1-SNAPSHOT</version>
     </parent>
     <artifactId>config-server</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
     <name>config-server</name>
     <description>config-server</description>
     <properties>

--- a/apps/backend/file-service/pom.xml
+++ b/apps/backend/file-service/pom.xml
@@ -8,7 +8,6 @@
         <version>0.0.1-SNAPSHOT</version>
     </parent>
     <artifactId>file-service</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
     <name>file-service</name>
     <description>file-service</description>
     <properties>

--- a/build-services.sh
+++ b/build-services.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+
+BACKEND_SERVICES="discovery-server config-server gateway user-service file-service sync-service"
+FRONTEND_SERVICE="client"
+DOCS_SERVICE="docs"
+ALL_SERVICES="$BACKEND_SERVICES $FRONTEND_SERVICE $DOCS_SERVICE"
+
+build_backend_service() {
+  local service=$1
+  echo "---------------------------------------"
+  echo "Building backend service: $service..."
+
+  cd "apps/backend/$service" || { echo "Error: Directory $service not found"; exit 1; }
+
+  echo "Running mvn dockerfile:build for $service..."
+  mvn package -DskipTests dockerfile:build || { echo "Error: Maven build failed for $service"; exit 1; }
+
+  VERSION=$(grep -m1 "<version>" pom.xml | sed 's/.*<version>\(.*\)<\/version>.*/\1/')
+  if [ -z "$VERSION" ]; then
+    echo "Error: Could not extract version from $service/pom.xml"
+    exit 1
+  fi
+  echo "Extracted version from pom.xml: $VERSION"
+
+  IMAGE_NAME="oakcan/$service"
+  VERSIONED_IMAGE="$IMAGE_NAME:$VERSION"
+  LATEST_IMAGE="$IMAGE_NAME:latest"
+
+  echo "Tagging $VERSIONED_IMAGE as $LATEST_IMAGE..."
+  docker tag "$VERSIONED_IMAGE" "$LATEST_IMAGE" || { echo "Error: Failed to tag $service image as latest"; exit 1; }
+
+  echo "$service built and tagged: $VERSIONED_IMAGE and $LATEST_IMAGE"
+  cd ../../../
+}
+
+# Function to build non-Maven service with Docker
+build_non_maven_service() {
+  local service=$1
+  echo "---------------------------------------"
+  echo "Building $service..."
+  local dockerfile="Dockerfile"
+
+  if [ "$service" = "client" ]; then
+    cd "apps/web" || { echo "Error: Directory $service not found"; exit 1; }
+  elif [ "$service" = "docs" ]; then
+    if [ ! -d "docs" ]; then { echo "Error: Directory $service not found"; exit 1; }; fi
+    dockerfile="./docs/Dockerfile"
+  else
+    echo "Error: Unknown service $service"
+    exit 1
+  fi
+
+  IMAGE_NAME="oakcan/$service"
+  LATEST_IMAGE="$IMAGE_NAME:latest"
+
+  echo "Running docker build for $service..."
+  docker build -t "$LATEST_IMAGE" . -f "$dockerfile" || { echo "Error: Docker build failed for $service"; exit 1; }
+
+  echo "$service built and tagged: $LATEST_IMAGE"
+
+  if [ "$service" = "client" ]; then
+    cd ../../
+  fi
+}
+
+# Function to check if a service is in a list
+contains_service() {
+  local service=$1
+  local service_list="$2"
+  echo "$service_list" | grep -qw "$service"
+}
+
+# Process arguments
+if [ $# -eq 0 ]; then
+  echo "No arguments provided. Building all services: $ALL_SERVICES"
+  for service in $BACKEND_SERVICES; do
+    build_backend_service "$service"
+  done
+  build_non_maven_service "$FRONTEND_SERVICE"
+  build_non_maven_service "$DOCS_SERVICE"
+else
+  for arg in "$@"; do
+    case "$arg" in
+      "backend")
+        echo "Building all backend services: $BACKEND_SERVICES"
+        for service in $BACKEND_SERVICES; do
+          build_backend_service "$service"
+        done
+        ;;
+      "client")
+        echo "Building frontend service: $FRONTEND_SERVICE"
+        build_non_maven_service "$FRONTEND_SERVICE"
+        ;;
+      "docs")
+        echo "Building docs service: $DOCS_SERVICE"
+        build_non_maven_service "$DOCS_SERVICE"
+        ;;
+      *)
+        # Check if it's a specific service
+        if contains_service "$arg" "$ALL_SERVICES"; then
+          if contains_service "$arg" "$BACKEND_SERVICES"; then
+            build_backend_service "$arg"
+          else
+            build_non_maven_service "$arg"
+          fi
+        else
+          echo "Error: Unknown service or option '$arg'. Valid options: backend, client, docs, or a specific service ($ALL_SERVICES)"
+          exit 1
+        fi
+        ;;
+    esac
+  done
+fi
+
+echo "---------------------------------------"
+echo "Build process completed successfully!"


### PR DESCRIPTION
### Description
- Added a  script in the root folder `build-services.sh` to build docker images easily. This script will be helpful in CI/CD and running services locally inside containers.
- This will build docker images for backend services(e.g. discovery-server, config-server, user-service, file-service, gateway etc), frontend, and docs.
- The script will package backend services and build images while skipping tests. As we need running instances of config-server and discovery-server to run tests successfully for core services, we're skipping tests. 
- For now, we're using the parent module's version for each service in the bakcend. Need to think about that in future if we have any inconsistency. 
### Usuage
Make the script executable:
```shell
chmod +x ./build-services.sh
```
Run with:
```shell
./build-services.sh [OPTIONS]
```
- No option: Build all services (backend, frontend, docs).
- `backend`: Build only backend services.
- `client`: Build only frontend.
- `docs`: Build only docs.
- `<service>`: Build a specific service (e.g., config-server).
- `<service1> <service2>`: Build a list of services(e.g. `./build-services.sh client config-server discovery-server docs gateway`).

### Related Issue
Closes #148 
<!-- If this PR addresses an issue, please link to it here (e.g., `#123`). -->
<!-- related to #4, closes #9 -->

### Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Chore (maintenance, refactoring, etc.)
- [ ] Other (please describe):

### Checklist

<!-- Please check the items that apply and make sure to complete them before submitting your PR. -->

- [x] I have tested my changes.
- [ ] I have updated the documentation (if necessary).
- [ ] I have added necessary tests (if applicable).

### Screenshots/videos (if applicable)

<!-- If your changes include visual updates, please include screenshots/gifs/videos here. -->

### Additional Context

<!-- Any other information or context that is helpful to understand your changes (e.g., implementation details, reasoning,
etc.). -->