### PR TITLE
feat: added UserEntityTemplate and TokenEntityTemplate in the user library

### DIFF
--- a/apps/backend/common/user/pom.xml
+++ b/apps/backend/common/user/pom.xml
@@ -34,7 +34,14 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>

--- a/apps/backend/common/user/src/main/java/lib/user/enums/TokenType.java
+++ b/apps/backend/common/user/src/main/java/lib/user/enums/TokenType.java
@@ -1,0 +1,15 @@
+package lib.user.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum TokenType {
+
+    EMAIL_VERIFICATION("email-verification"),
+    PASSWORD_RESET("password-reset"),
+    REFRESH("refresh");
+
+    private final String token;
+}

--- a/apps/backend/common/user/src/main/java/lib/user/model/TokenEntityTemplate.java
+++ b/apps/backend/common/user/src/main/java/lib/user/model/TokenEntityTemplate.java
@@ -1,0 +1,49 @@
+package lib.user.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+import java.sql.Timestamp;
+import java.util.UUID;
+import lib.user.enums.TokenType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@MappedSuperclass
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+public class TokenEntityTemplate {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(name = "token_hash", nullable = false, unique = true, length = 72)
+    private String tokenHash;
+
+    @Column(name = "is_used", nullable = false)
+    private boolean used;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, updatable = false)
+    private TokenType type;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    @CreationTimestamp
+    private Timestamp createdAt;
+
+    @Column(name = "expires_at", nullable = false, updatable = false)
+    private Timestamp expiresAt;
+}

--- a/apps/backend/common/user/src/main/java/lib/user/model/UserEntityTemplate.java
+++ b/apps/backend/common/user/src/main/java/lib/user/model/UserEntityTemplate.java
@@ -1,0 +1,88 @@
+package lib.user.model;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.OneToMany;
+import java.security.Principal;
+import java.sql.Timestamp;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+@MappedSuperclass
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+public class UserEntityTemplate implements UserDetails, Principal {
+
+    @Id
+    @Column(name = "id")
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(name = "email", unique = true)
+    private String email;
+
+    @Column(name = "password_hash", length = 72)
+    private String passwordHash;
+
+    @Column(name = "oauth_id")
+    private String oauthId;
+
+    @Column(name = "name")
+    private String fullName;
+
+    @Column(name = "verified", nullable = false)
+    private boolean verified = false;
+
+    @Column(name = "created_at", updatable = false)
+    @CreationTimestamp
+    private Timestamp createdAt;
+
+    @Column(name = "updated_at")
+    @UpdateTimestamp
+    private Timestamp updatedAt;
+
+    @Override
+    public String getName() {
+        return this.email;
+    } // take note here
+
+    @Override
+    public String getPassword() {
+        return this.passwordHash;
+    }
+
+    @Override
+    public String getUsername() {
+        return this.email;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(); // for now we don't have any roles
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return this.verified;
+    }
+}

--- a/apps/backend/common/user/src/main/resources/application.properties
+++ b/apps/backend/common/user/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=user

--- a/apps/backend/config-server/src/main/resources/config/user-service/user-service-dev.yaml
+++ b/apps/backend/config-server/src/main/resources/config/user-service/user-service-dev.yaml
@@ -2,9 +2,10 @@ example:
   property: I AM THE DEV
 spring:
   jpa:
-    hibernate:
+    database-platform: org.hibernate.dialect.PostgreSQLDialect
     properties:
-      dialect: org.hibernate.dialect.PostgreSQLDialect
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
     defer-datasource-initialization: true
     show-sql: true
   sql:

--- a/apps/backend/user-service/pom.xml
+++ b/apps/backend/user-service/pom.xml
@@ -109,6 +109,11 @@
             <groupId>org.eclipse.angus</groupId>
             <artifactId>jakarta.mail</artifactId>
         </dependency>
+        <dependency>
+            <groupId>lib</groupId>
+            <artifactId>user</artifactId>
+            <version>0.0.1</version>
+        </dependency>
     </dependencies>
     <dependencyManagement>
         <dependencies>

--- a/apps/backend/user-service/src/main/java/com/bytebandit/userservice/controller/EmailVerificationController.java
+++ b/apps/backend/user-service/src/main/java/com/bytebandit/userservice/controller/EmailVerificationController.java
@@ -1,10 +1,10 @@
 package com.bytebandit.userservice.controller;
 
-import com.bytebandit.userservice.enums.TokenType;
 import com.bytebandit.userservice.service.TokenVerificationService;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.constraints.NotNull;
 import java.io.IOException;
+import lib.user.enums.TokenType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;

--- a/apps/backend/user-service/src/main/java/com/bytebandit/userservice/model/TokenEntity.java
+++ b/apps/backend/user-service/src/main/java/com/bytebandit/userservice/model/TokenEntity.java
@@ -6,9 +6,13 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lib.user.model.TokenEntityTemplate;
+import lombok.Getter;
+import lombok.Setter;
 
 @Entity
 @Table(name = "tokens")
+@Getter
+@Setter
 public class TokenEntity extends TokenEntityTemplate {
 
     /**

--- a/apps/backend/user-service/src/main/java/com/bytebandit/userservice/model/TokenEntity.java
+++ b/apps/backend/user-service/src/main/java/com/bytebandit/userservice/model/TokenEntity.java
@@ -1,57 +1,16 @@
 package com.bytebandit.userservice.model;
 
-import com.bytebandit.userservice.enums.TokenType;
-import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import java.sql.Timestamp;
-import java.util.UUID;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import org.hibernate.annotations.CreationTimestamp;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import lib.user.model.TokenEntityTemplate;
 
 @Entity
 @Table(name = "tokens")
-@Data
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
-@EntityListeners(AuditingEntityListener.class)
-public class TokenEntity {
-    
-    @Id
-    @GeneratedValue(strategy = GenerationType.UUID)
-    private UUID id;
-    
-    @Column(name = "token_hash", nullable = false, unique = true, length = 72)
-    private String tokenHash;
-    
-    @Column(name = "is_used", nullable = false)
-    private boolean used;
-    
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false, updatable = false)
-    private TokenType type;
-    
-    @Column(name = "created_at", nullable = false, updatable = false)
-    @CreationTimestamp
-    private Timestamp createdAt;
-    
-    @Column(name = "expires_at", nullable = false, updatable = false)
-    private Timestamp expiresAt;
-    
+public class TokenEntity extends TokenEntityTemplate {
+
     /**
      * Many-to-one relationship with the UserEntity. Fetches the user lazily and joins on the
      * 'user_id' column.

--- a/apps/backend/user-service/src/main/java/com/bytebandit/userservice/model/UserEntity.java
+++ b/apps/backend/user-service/src/main/java/com/bytebandit/userservice/model/UserEntity.java
@@ -7,9 +7,13 @@ import jakarta.persistence.Table;
 import java.util.HashSet;
 import java.util.Set;
 import lib.user.model.UserEntityTemplate;
+import lombok.Getter;
+import lombok.Setter;
 
 @Entity
 @Table(name = "users")
+@Getter
+@Setter
 public class UserEntity extends UserEntityTemplate {
 
     /**

--- a/apps/backend/user-service/src/main/java/com/bytebandit/userservice/model/UserEntity.java
+++ b/apps/backend/user-service/src/main/java/com/bytebandit/userservice/model/UserEntity.java
@@ -1,69 +1,16 @@
 package com.bytebandit.userservice.model;
 
 import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
-import java.security.Principal;
-import java.sql.Timestamp;
-import java.util.Collection;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
-import java.util.UUID;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
-import org.hibernate.annotations.CreationTimestamp;
-import org.hibernate.annotations.UpdateTimestamp;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.userdetails.UserDetails;
+import lib.user.model.UserEntityTemplate;
 
 @Entity
-@Getter
-@Setter
-@Builder
-@AllArgsConstructor
-@NoArgsConstructor
 @Table(name = "users")
-@EntityListeners(AuditingEntityListener.class)
-public class UserEntity implements UserDetails, Principal {
-
-    @Id
-    @Column(name = "id")
-    @GeneratedValue(strategy = GenerationType.UUID)
-    private UUID id;
-
-    @Column(name = "email", unique = true)
-    private String email;
-
-    @Column(name = "password_hash", length = 72)
-    private String passwordHash;
-
-    @Column(name = "oauth_id")
-    private String oauthId;
-
-    @Column(name = "name")
-    private String fullName;
-
-    @Column(name = "verified", nullable = false)
-    private boolean verified = false;
-
-    @Column(name = "created_at", updatable = false)
-    @CreationTimestamp
-    private Timestamp createdAt;
-
-    @Column(name = "updated_at")
-    @UpdateTimestamp
-    private Timestamp updatedAt;
+public class UserEntity extends UserEntityTemplate {
 
     /**
      * One-to-many relationship with TokenEntity. cascade = CascadeType.ALL - This means that any
@@ -75,28 +22,4 @@ public class UserEntity implements UserDetails, Principal {
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private Set<TokenEntity> tokens = new HashSet<>();
 
-    @Override
-    public String getName() {
-        return this.email;
-    } // take note here
-
-    @Override
-    public String getPassword() {
-        return this.passwordHash;
-    }
-
-    @Override
-    public String getUsername() {
-        return this.email;
-    }
-
-    @Override
-    public Collection<? extends GrantedAuthority> getAuthorities() {
-        return List.of(); // for now we don't have any roles
-    }
-
-    @Override
-    public boolean isEnabled() {
-        return this.verified;
-    }
 }

--- a/apps/backend/user-service/src/main/java/com/bytebandit/userservice/repository/TokenRepository.java
+++ b/apps/backend/user-service/src/main/java/com/bytebandit/userservice/repository/TokenRepository.java
@@ -1,10 +1,10 @@
 package com.bytebandit.userservice.repository;
 
-import com.bytebandit.userservice.enums.TokenType;
 import com.bytebandit.userservice.model.TokenEntity;
 import java.sql.Timestamp;
 import java.util.Optional;
 import java.util.UUID;
+import lib.user.enums.TokenType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/apps/backend/user-service/src/main/java/com/bytebandit/userservice/service/TokenVerificationService.java
+++ b/apps/backend/user-service/src/main/java/com/bytebandit/userservice/service/TokenVerificationService.java
@@ -1,12 +1,12 @@
 package com.bytebandit.userservice.service;
 
-import com.bytebandit.userservice.enums.TokenType;
 import com.bytebandit.userservice.exception.FailedEmailVerificationAttemptException;
 import com.bytebandit.userservice.model.TokenEntity;
 import com.bytebandit.userservice.repository.TokenRepository;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.UUID;
+import lib.user.enums.TokenType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;

--- a/apps/backend/user-service/src/test/java/com/bytebandit/userservice/entity/UserAndTokenEntityIntegrationTest.java
+++ b/apps/backend/user-service/src/test/java/com/bytebandit/userservice/entity/UserAndTokenEntityIntegrationTest.java
@@ -1,5 +1,7 @@
 package com.bytebandit.userservice.entity;
 
+import static com.bytebandit.userservice.utils.TestUtils.createToken;
+import static com.bytebandit.userservice.utils.TestUtils.createUser;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -64,33 +66,5 @@ class UserAndTokenEntityIntegrationTest {
 
         UserEntity retrievedUser = entityManager.find(UserEntity.class, user.getId());
         assertEquals(2, retrievedUser.getTokens().size());
-    }
-
-    private TokenEntity createToken(UserEntity user, TokenType type) {
-        TokenEntity tokenEntity = new TokenEntity();
-        tokenEntity.setTokenHash(UUID.randomUUID().toString());
-        tokenEntity.setType(type);
-        tokenEntity.setExpiresAt(Timestamp.valueOf(LocalDateTime.now().plusDays(1)));
-        tokenEntity.setUser(user);
-        tokenEntity.setUsed(false);
-        return tokenEntity;
-    }
-
-    private TokenEntity createToken(UserEntity user) {
-        TokenEntity tokenEntity = new TokenEntity();
-        tokenEntity.setTokenHash(UUID.randomUUID().toString());
-        tokenEntity.setType(TokenType.EMAIL_VERIFICATION);
-        tokenEntity.setExpiresAt(Timestamp.valueOf(LocalDateTime.now().plusDays(1)));
-        tokenEntity.setUser(user);
-        tokenEntity.setUsed(false);
-        return tokenEntity;
-    }
-
-    private UserEntity createUser() {
-        UserEntity user = new UserEntity();
-        user.setEmail("user@example.com");
-        user.setFullName("Test User");
-        user.setPasswordHash(UUID.randomUUID().toString());
-        return user;
     }
 }

--- a/apps/backend/user-service/src/test/java/com/bytebandit/userservice/entity/UserAndTokenEntityIntegrationTest.java
+++ b/apps/backend/user-service/src/test/java/com/bytebandit/userservice/entity/UserAndTokenEntityIntegrationTest.java
@@ -3,46 +3,35 @@ package com.bytebandit.userservice.entity;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-import com.bytebandit.userservice.enums.TokenType;
 import com.bytebandit.userservice.model.TokenEntity;
 import com.bytebandit.userservice.model.UserEntity;
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.util.UUID;
+import lib.user.enums.TokenType;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
-import org.springframework.context.annotation.Import;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.security.crypto.password.PasswordEncoder;
+
 
 @DataJpaTest
-@Import(BCryptPasswordEncoder.class)
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 class UserAndTokenEntityIntegrationTest {
 
     @Autowired
     private TestEntityManager entityManager;
 
-    @Autowired
-    private PasswordEncoder passwordEncoder;
-
     /**
      * Test to verify that when a user is deleted, all associated tokens are also deleted.
      */
     @Test
     void whenUserIsDeleted_thenAssociatedTokensAreDeleted() {
-        UserEntity user = createAndPersistUser();
+        UserEntity user = createUser();
+        user = entityManager.persistAndFlush(user);
 
-        TokenEntity tokenEntity = TokenEntity.builder()
-            .tokenHash(passwordEncoder.encode(UUID.randomUUID().toString()))
-            .type(TokenType.REFRESH)
-            .expiresAt(Timestamp.valueOf(LocalDateTime.now().plusDays(1)))
-            .user(user)
-            .used(false)
-            .build();
+        TokenEntity tokenEntity = createToken(user);
         user.getTokens().add(tokenEntity);
 
         entityManager.persistAndFlush(tokenEntity);
@@ -62,23 +51,11 @@ class UserAndTokenEntityIntegrationTest {
      */
     @Test
     void whenMultipleTokensAreAddedToUser_thenAllTokensArePersisted() {
-        UserEntity user = createAndPersistUser();
+        UserEntity user = createUser();
+        user = entityManager.persistAndFlush(user);
 
-        TokenEntity token1 = TokenEntity.builder()
-            .tokenHash(passwordEncoder.encode(UUID.randomUUID().toString()))
-            .type(TokenType.EMAIL_VERIFICATION)
-            .expiresAt(Timestamp.valueOf(LocalDateTime.now().plusDays(1)))
-            .user(user)
-            .used(false)
-            .build();
-
-        TokenEntity token2 = TokenEntity.builder()
-            .tokenHash(passwordEncoder.encode(UUID.randomUUID().toString()))
-            .type(TokenType.PASSWORD_RESET)
-            .expiresAt(Timestamp.valueOf(LocalDateTime.now().plusDays(2)))
-            .user(user)
-            .used(false)
-            .build();
+        TokenEntity token1 = createToken(user);
+        TokenEntity token2 = createToken(user, TokenType.PASSWORD_RESET);
 
         user.getTokens().add(token1);
         user.getTokens().add(token2);
@@ -89,12 +66,31 @@ class UserAndTokenEntityIntegrationTest {
         assertEquals(2, retrievedUser.getTokens().size());
     }
 
-    private UserEntity createAndPersistUser() {
+    private TokenEntity createToken(UserEntity user, TokenType type) {
+        TokenEntity tokenEntity = new TokenEntity();
+        tokenEntity.setTokenHash(UUID.randomUUID().toString());
+        tokenEntity.setType(type);
+        tokenEntity.setExpiresAt(Timestamp.valueOf(LocalDateTime.now().plusDays(1)));
+        tokenEntity.setUser(user);
+        tokenEntity.setUsed(false);
+        return tokenEntity;
+    }
+
+    private TokenEntity createToken(UserEntity user) {
+        TokenEntity tokenEntity = new TokenEntity();
+        tokenEntity.setTokenHash(UUID.randomUUID().toString());
+        tokenEntity.setType(TokenType.EMAIL_VERIFICATION);
+        tokenEntity.setExpiresAt(Timestamp.valueOf(LocalDateTime.now().plusDays(1)));
+        tokenEntity.setUser(user);
+        tokenEntity.setUsed(false);
+        return tokenEntity;
+    }
+
+    private UserEntity createUser() {
         UserEntity user = new UserEntity();
         user.setEmail("user@example.com");
         user.setFullName("Test User");
-        user.setPasswordHash("hashedPassword");
-        entityManager.persistAndFlush(user);
+        user.setPasswordHash(UUID.randomUUID().toString());
         return user;
     }
 }

--- a/apps/backend/user-service/src/test/java/com/bytebandit/userservice/utils/TestUtils.java
+++ b/apps/backend/user-service/src/test/java/com/bytebandit/userservice/utils/TestUtils.java
@@ -1,0 +1,42 @@
+package com.bytebandit.userservice.utils;
+
+import com.bytebandit.userservice.model.TokenEntity;
+import com.bytebandit.userservice.model.UserEntity;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lib.user.enums.TokenType;
+
+public class TestUtils {
+
+    /** Create a token entity with a user and a specific token type. */
+    public static TokenEntity createToken(UserEntity user, TokenType type) {
+        TokenEntity tokenEntity = new TokenEntity();
+        tokenEntity.setTokenHash(UUID.randomUUID().toString());
+        tokenEntity.setType(type);
+        tokenEntity.setExpiresAt(Timestamp.valueOf(LocalDateTime.now().plusDays(1)));
+        tokenEntity.setUser(user);
+        tokenEntity.setUsed(false);
+        return tokenEntity;
+    }
+
+    /** Create a token entity with a user and the default token type (EMAIL_VERIFICATION). */
+    public static TokenEntity createToken(UserEntity user) {
+        TokenEntity tokenEntity = new TokenEntity();
+        tokenEntity.setTokenHash("hashedToken");
+        tokenEntity.setType(TokenType.EMAIL_VERIFICATION);
+        tokenEntity.setExpiresAt(Timestamp.valueOf(LocalDateTime.now().plusDays(1)));
+        tokenEntity.setUser(user);
+        tokenEntity.setUsed(false);
+        return tokenEntity;
+    }
+
+    /** Create a user entity with default values. */
+    public static UserEntity createUser() {
+        UserEntity user = new UserEntity();
+        user.setEmail("user@example.com");
+        user.setFullName("Test User");
+        user.setPasswordHash(UUID.randomUUID().toString());
+        return user;
+    }
+}


### PR DESCRIPTION
### Description

- Movded `UserEntity` and `TokenEntity` in the user library as `UserEntityTemplate` and `TokenEntityTemplate`
- Changed `UserEntity` and `TokenEntity` to reuse the newer `UserEntityTemplate` and `TokenEntityTemplate`
- Changed the entity tests 

**Check the change in `user-service-dev.yaml` in config-server**

### Related Issue
closes #150 
### Type of Change

- [ ] Bug 
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Chore (maintenance, refactoring, etc.)
- [ ] Other (please describe):

### Checklist

- [x] I have tested my changes.
- [ ] I have updated the documentation (if necessary).
- [ ] I have added necessary tests (if applicable).

### Screenshots/videos (if applicable)

### Additional Context
We need to define the entity relationships in the services, bacause library does not have actual entities.  