### PR TITLE
feature(jaCoCo): setup JaCoCo with report aggregation in a separate module

### DIFF
--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -7,6 +7,8 @@
     <file url="file://$PROJECT_DIR$/apps/backend/common/user/src/main/resources" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/apps/backend/config-server/src/main/java" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/apps/backend/config-server/src/main/resources" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/apps/backend/coverage/src/main/java" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/apps/backend/coverage/src/main/resources" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/apps/backend/discovery-server/src/main/java" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/apps/backend/discovery-server/src/main/resources" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/apps/backend/file-service/src/main/java" charset="UTF-8" />

--- a/apps/backend/config-server/src/main/resources/config/gateway/gateway-dev.yaml
+++ b/apps/backend/config-server/src/main/resources/config/gateway/gateway-dev.yaml
@@ -1,6 +1,5 @@
 spring:
   jpa:
-    database-platform: org.hibernate.dialect.PostgreSQLDialect
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect

--- a/apps/backend/coverage/pom.xml
+++ b/apps/backend/coverage/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.bytebandit</groupId>
+        <artifactId>oakcan-backend</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>coverage</artifactId>
+    <description>Compute aggregated test code coverage</description>
+
+
+    <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>user-service</artifactId>
+            <version>0.0.1-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>gateway</artifactId>
+            <version>0.0.1-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>file-service</artifactId>
+            <version>0.0.1-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>discovery-server</artifactId>
+            <version>0.0.1-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.12</version>
+                <executions>
+                    <execution>
+                        <id>report-aggregate</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>report-aggregate</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/apps/backend/discovery-server/pom.xml
+++ b/apps/backend/discovery-server/pom.xml
@@ -65,6 +65,10 @@
                 <groupId>com.spotify</groupId>
                 <artifactId>dockerfile-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 

--- a/apps/backend/file-service/pom.xml
+++ b/apps/backend/file-service/pom.xml
@@ -136,6 +136,10 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/apps/backend/gateway/pom.xml
+++ b/apps/backend/gateway/pom.xml
@@ -129,6 +129,10 @@
                     </annotationProcessorPaths>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/apps/backend/gateway/src/test/resources/application-test.yaml
+++ b/apps/backend/gateway/src/test/resources/application-test.yaml
@@ -11,3 +11,10 @@ spring:
     url: ${USER_TEST_DB_URL}
     username: ${POSTGRES_USERNAME}
     password: ${POSTGRES_PASSWORD}
+jwt:
+  secret: ${JWT_SECRET}
+app:
+  permitted:
+    routes: /api/v1/user/login,/api/v1/user/register,/api/v1/user/verify,/csrf,/test-csrf,/actuator/*
+  access-token-expiration: 3600
+  refresh-token-expiration: 86400

--- a/apps/backend/gateway/src/test/resources/application-test.yaml
+++ b/apps/backend/gateway/src/test/resources/application-test.yaml
@@ -8,6 +8,6 @@ spring:
       ddl-auto: update
   datasource:
     driver-class-name: org.postgresql.Driver
-    url: ${USER_DEV_DB_URL}
+    url: ${USER_TEST_DB_URL}
     username: ${POSTGRES_USERNAME}
     password: ${POSTGRES_PASSWORD}

--- a/apps/backend/pom.xml
+++ b/apps/backend/pom.xml
@@ -17,12 +17,16 @@
         <docker.image.prefix>oakcan</docker.image.prefix>
         <spring-boot.version>3.4.1</spring-boot.version>
         <java.version>17</java.version>
+        <maven.compiler.target>${java.version}</maven.compiler.target>
+        <maven.compiler.source>${java.version}</maven.compiler.source>
+        <skipUnitTests>false</skipUnitTests>
     </properties>
 
 
     <modules>
         <module>discovery-server</module>
         <module>common</module>
+        <module>coverage</module>
         <module>file-service</module>
         <module>gateway</module>
         <module>sync-service</module>
@@ -120,6 +124,7 @@
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>3.5.2</version>
                     <configuration>
+                        <skipTests>${skipUnitTests}</skipTests>
                         <includes>
                             <include>**/*Test.java</include>
                             <include>**/*Tests.java</include>
@@ -148,12 +153,33 @@
                             <id>integration-test</id>
                             <goals>
                                 <goal>integration-test</goal>
+                                <goal>verify</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
+                    <groupId>org.jacoco</groupId>
+                    <artifactId>jacoco-maven-plugin</artifactId>
+                    <version>0.8.12</version>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>prepare-agent</goal>
                             </goals>
                         </execution>
                         <execution>
-                            <id>verify</id>
+                            <id>report</id>
+                            <phase>test</phase>
                             <goals>
-                                <goal>verify</goal>
+                                <goal>report</goal>
+                            </goals>
+                        </execution>
+                        <execution>
+                            <id>report-integration</id>
+                            <phase>verify</phase>
+                            <goals>
+                                <goal>report</goal>
                             </goals>
                         </execution>
                     </executions>

--- a/apps/backend/sync-service/pom.xml
+++ b/apps/backend/sync-service/pom.xml
@@ -118,6 +118,10 @@
                 <groupId>com.spotify</groupId>
                 <artifactId>dockerfile-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/apps/backend/user-service/pom.xml
+++ b/apps/backend/user-service/pom.xml
@@ -170,6 +170,10 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,9 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <sonar.coverage.jacoco.xmlReportPaths>
+            ${project.basedir}/apps/backend/coverage/target/jacoco-aggregate/jacoco.xml,
+        </sonar.coverage.jacoco.xmlReportPaths>
     </properties>
 
 


### PR DESCRIPTION
Add `jacoco` plugin and setup aggregated reporting of test coverage

### Description
- Added `jacoco` in the parent pom. Child modules are inheriting it. 
- Add a new module named `coverage` that'll handle aggregated test reporting of all the modules.

### Usage
During development, run `mvn verify` inside `apps/backend` or a particular module to generate the `jacoco` report. You can then view individual module's report at each modules `target` directory. Also you can view aggregated result at the `coverage` module. Go to `[module_name]/target/site` folder and preview the `index.html` to view the result. You'll see a table as shown in the image(aggregated result inside `coverage` module): 
![image](https://github.com/user-attachments/assets/40e43b18-2582-4a1a-b2cb-b15e137bd554)


### Related Issue
Closes #159 
<!-- If this PR addresses an issue, please link to it here (e.g., `#123`). -->
<!-- related to #4, closes #9 -->

### Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Chore (maintenance, refactoring, etc.)
- [ ] Other (please describe):

### Checklist

<!-- Please check the items that apply and make sure to complete them before submitting your PR. -->

- [x] I have tested my changes.
- [ ] I have updated the documentation (if necessary).
- [ ] I have added necessary tests (if applicable).

### Screenshots/videos (if applicable)

<!-- If your changes include visual updates, please include screenshots/gifs/videos here. -->

### Additional Context

<!-- Any other information or context that is helpful to understand your changes (e.g., implementation details, reasoning, etc.). -->
