### PR TITLE
chore: refactored run-services.sh and docker-compose.apps.yml

### DIFF
--- a/build-services.sh
+++ b/build-services.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 
 BACKEND_SERVICES="discovery-server config-server gateway user-service file-service sync-service"
+INFRA_SERVICES="user-dev-db mailhog"
 FRONTEND_SERVICE="client"
 DOCS_SERVICE="docs"
-ALL_SERVICES="$BACKEND_SERVICES $FRONTEND_SERVICE $DOCS_SERVICE"
+ALL_SERVICES="$BACKEND_SERVICES $FRONTEND_SERVICE $DOCS_SERVICE $INFRA_SERVICES"
 
 build_backend_service() {
   local service=$1
@@ -98,13 +99,16 @@ else
       *)
         # Check if it's a specific service
         if contains_service "$arg" "$ALL_SERVICES"; then
-          if contains_service "$arg" "$BACKEND_SERVICES"; then
+          if contains_service "$arg" "$INFRA_SERVICES";then
+            echo "Skipping build for infrastructure service: $arg"
+            continue
+          elif contains_service "$arg" "$BACKEND_SERVICES"; then
             build_backend_service "$arg"
           else
             build_non_maven_service "$arg"
           fi
         else
-          echo "Error: Unknown service or option '$arg'. Valid options: backend, client, docs, or a specific service ($ALL_SERVICES)"
+          echo "Error: Unknown service or option '$arg'. Valid options: ($ALL_SERVICES)"
           exit 1
         fi
         ;;

--- a/docker-compose.apps.yml
+++ b/docker-compose.apps.yml
@@ -2,6 +2,8 @@ services:
   discovery-server:
     image: oakcan/discovery-server:latest
     container_name: oakcan-discovery-server
+    profiles:
+      - core
     ports:
       - "8761:8761"
     healthcheck:
@@ -14,6 +16,8 @@ services:
     container_name: oakcan-config-server
     environment:
       - EUREKA_CLIENT_SERVICEURL_DEFAULTZONE=http://discovery-server:8761/eureka/
+    profiles:
+      - core
     ports:
       - "8071:8071"
     healthcheck:
@@ -27,10 +31,16 @@ services:
   gateway:
     image: oakcan/gateway:latest
     container_name: oakcan-gateway
+    profiles:
+      - core
     ports:
       - "8084:8084"
     environment:
       - EUREKA_CLIENT_SERVICEURL_DEFAULTZONE=http://discovery-server:8761/eureka/
+      - USER_DEV_DB_URL=jdbc:postgresql://user-dev-db:5432/user-dev-db
+      - POSTGRES_USERNAME=postgres
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - JWT_SECRET=${JWT_SECRET}
     healthcheck:
       test: [ "CMD", "wget", "-qO-", "http://localhost:8084/actuator/health" ]
       interval: 10s
@@ -41,9 +51,13 @@ services:
         condition: service_healthy
       config-server:
         condition: service_healthy
+      user-dev-db:
+        condition: service_healthy
   file-service:
     image: oakcan/file-service:latest
     container_name: oakcan-file-service
+    profiles:
+      - core
     ports:
       - "8081:8081"
     environment:
@@ -58,6 +72,8 @@ services:
   sync-service:
     image: oakcan/sync-service:latest
     container_name: oakcan-sync-service
+    profiles:
+      - core
     ports:
       - "8082:8082"
     environment:
@@ -72,6 +88,8 @@ services:
   user-service:
     image: oakcan/user-service:latest
     container_name: oakcan-user-service
+    profiles:
+      - core
     ports:
       - "8083:8083"
     environment:
@@ -99,6 +117,8 @@ services:
   user-dev-db:
     image: postgres:17-alpine
     container_name: user-dev-db
+    profiles:
+      - infra
     ports:
       - "15432:5432"
     environment:
@@ -117,6 +137,8 @@ services:
   mailhog:
     image: mailhog/mailhog
     container_name: mailhog
+    profiles:
+      - infra
     ports:
       - "1025:1025"
       - "8025:8025"
@@ -128,15 +150,19 @@ services:
       start_period: 5s
 
   client:
-    image: oakcan/client:0.0.1-SNAPSHOT
+    image: oakcan/client:latest
     container_name: oakcan-client
+    profiles:
+      - core
     build:
       context: ./apps/web
     ports:
       - "3000:3000"
   docs:
-    image: oakcan/docs:0.0.1-SNAPSHOT
+    image: oakcan/docs:latest
     container_name: oakcan-docs
+    profiles:
+      - core
     build:
       context: docs
     ports:

--- a/run-services.sh
+++ b/run-services.sh
@@ -2,57 +2,157 @@
 set -e  # Exit on error
 
 # List of backend services
+COMPOSE_FILE="docker-compose.apps.yml"
+INFRA_SERVICES="user-dev-db mailhog"
 BACKEND_SERVICES="discovery-server config-server gateway user-service file-service sync-service"
 FRONTEND_SERVICE="client"
 DOCS_SERVICE="docs"
-ALL_SERVICES="$BACKEND_SERVICES $FRONTEND_SERVICE $DOCS_SERVICE"
+ALL_SERVICES="$BACKEND_SERVICES $FRONTEND_SERVICE $DOCS_SERVICE $INFRA_SERVICES"
+ACTIVE_PROFILES="--profile infra --profile core"
 
-# Function to rebuild and restart a specific service
-rebuild_service() {
+# --- Helper Functions ---
+usage() {
+  echo "Usage: $0 <action> [service...] [options]"
+  echo ""
+  echo "Actions:"
+  echo "  start   Build (if needed) and start specified services (or all core/infra if none specified)."
+  echo "  stop    Stop specified services (or all)."
+  echo "  restart Stop, remove, build (optional), and start specified services."
+  echo "  down    Stop and remove all containers, networks defined in the compose file."
+  echo ""
+  echo "Services:"
+  echo "  <service_name>  Specify one or more service names (e.g., user-service gateway)."
+  echo "  backend         Apply action to all backend services ($BACKEND_SERVICES)."
+  echo "  all             Apply action to all defined services ($ALL_SERVICES)."
+  echo "  (none)          Default depends on action (e.g., 'start' defaults to core+infra, 'ps' shows all)."
+  echo ""
+  echo "Options:"
+  echo "  -n, --no-build   Skip the build step during 'start' or 'restart'."
+  echo "  -h, --help       Show this help message."
+  exit 1
+}
+
+ACTION=""
+TARGET_SERVICES=()
+NO_BUILD=false
+
+run_compose() {
+  docker compose -f "$COMPOSE_FILE" $ACTIVE_PROFILES "$@"
+}
+
+# Function to check if a service is in a list
+contains_service() {
   local service=$1
+  local service_list="$2"
+  echo "$service_list" | grep -qw "$service"
+}
 
-   if [[ " ${ALL_SERVICES[*]} " =~ ${service} ]]; then
-      if ! ./build-services.sh "$service"; then  # Build the specified service
-        echo "ERROR: FAILED TO BUILD $service"
+
+# Parse action first
+if [[ $# -eq 0 ]]; then
+  usage
+fi
+ACTION=$1
+shift
+if [[ "$ACTION" == "-h" || "$ACTION" == "--help" ]]; then
+  usage
+elif [[ "$ACTION" != "start" && "$ACTION" != "stop" && "$ACTION" != "restart" && "$ACTION" != "down" && "$ACTION" != "-h" && "$ACTION" != "--help" ]]; then
+  echo "Error: Invalid action '$ACTION'. Valid actions are: start, stop, restart, down, -h, --help."
+  exit 1
+fi
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -n|--no-build)
+      NO_BUILD=true
+      shift
+      ;;
+    backend)
+      TARGET_SERVICES+=("$BACKEND_SERVICES")
+      shift
+      ;;
+    infra)
+      NO_BUILD=true # for infra, we don't need to build images
+      TARGET_SERVICES+=("$INFRA_SERVICES")
+      shift
+      ;;
+    all)
+      TARGET_SERVICES+=("$ALL_SERVICES")
+      shift
+      ;;
+    -*)
+      echo "Error: Invalid option '$1'. Use -h or --help for usage."
+      exit 1
+      ;;
+    *) # it's a service name
+      if contains_service "$1" "$ALL_SERVICES"; then
+        TARGET_SERVICES+=("$1")
+      else
+        echo "Error: Unknown service '$1'. Valid options: backend, all, infra, or a specific service ($ALL_SERVICES)"
         exit 1
       fi
-   else
-     echo "Service $service not found!"
-     exit 1
-   fi
+      shift
+      ;;
+  esac
+done
+# remove duplicates
+mapfile -t TARGET_SERVICES < <(echo "${TARGET_SERVICES[@]}" | tr ' ' '\n' | sort -u)
 
-  echo "Stopping $service..."
-  docker-compose -f docker-compose.apps.yml stop "$service" || { echo "ERROR: FAILED TO STOP $service"; exit 1; }
 
-  echo "Removing old container for $service..."
-  docker-compose -f docker-compose.apps.yml rm -f "$service" || { echo "ERROR: FAILED TO REMOVE $service CONTAINER"; exit 1; }
-
-  echo "Starting $service..."
-  docker-compose -f docker-compose.apps.yml up -d "$service" || { echo "ERROR: FAILED TO START $service"; exit 1; }
-}
-
-# Full rebuild (if no arguments are provided)
-full_rebuild() {
-  for service in $ALL_SERVICES; do
-    rebuild_service "$service"
-  done
-
-  echo "Removing dangling images..."
-  docker image prune -f
-
-  echo "Starting all application services..."
-  docker-compose -f docker-compose.apps.yml up -d --remove-orphans
-}
-
-if [[ -n "$1" ]]; then
-  if [ "$1" = "backend" ]; then
-    echo "Rebuilding all backend services..."
-    for service in $BACKEND_SERVICES; do
-      rebuild_service "$service"  # Rebuild and restart all backend services
-    done
-  else
-  rebuild_service "$1"  # Rebuild and restart only the specified service
-  fi
-else
-  full_rebuild  # Rebuild all services if no argument is provided
+echo "Action: $ACTION"
+if [[ ${#TARGET_SERVICES[*]} -gt 0 ]]; then
+    echo "Target(s): ${TARGET_SERVICES[*]}"
 fi
+echo "Options: No-Build=${NO_BUILD}"
+echo "---"
+
+case "$ACTION" in
+  start)
+    if [[ "$NO_BUILD" = false ]]; then
+      echo "Building necessary images..."
+      # Build only targets if specified, otherwise build based on profiles for 'up'
+      if [[ ${#TARGET_SERVICES[@]} -gt 0 ]]; then
+          chmod +x ./build-services.sh
+          ./build-services.sh "${TARGET_SERVICES[@]}"
+      fi
+    else
+      echo "Skipping build step..."
+    fi
+    echo "Starting services..."
+    # Start specific targets, or default to core+infra profiles if no targets given
+    run_compose up -d --remove-orphans "${TARGET_SERVICES[@]}"
+  ;;
+  stop)
+    echo "Stopping services..."
+    run_compose stop "${TARGET_SERVICES[@]}"
+  ;;
+  restart)
+    echo "Restarting services..."
+    # 1. Stop
+    run_compose stop "${TARGET_SERVICES[@]}"
+    # 2. Remove
+    run_compose rm -f "${TARGET_SERVICES[@]}"
+    # 3. Build (if needed)
+    if [[ "$NO_BUILD" = false ]]; then
+      echo "Building necessary images..."
+      # Build only targets if specified, otherwise build based on profiles for 'up'
+      if [[ ${#TARGET_SERVICES[@]} -gt 0 ]]; then
+          chmod +x ./build-services.sh
+          ./build-services.sh "${TARGET_SERVICES[@]}"
+      fi
+    else
+      echo "Skipping build step..."
+    fi
+    # 4. Start
+    echo "Starting services..."
+    run_compose up -d --remove-orphans "${TARGET_SERVICES[@]}"
+  ;;
+  down)
+    echo "Stopping and removing all services..."
+    run_compose down --remove-orphans
+  ;;
+  *)
+    echo "Error: Unknown action '$ACTION'."
+    exit 1
+  ;;
+esac


### PR DESCRIPTION
### Description
This PR introduces a robust CLI wrapper for `docker compose` operations:
- Added profiles to services in the docker-compose of `docker-compose.apps.yml`.
- Adds support for `start`, `stop`, `restart`, and `down` actions across modular service groups (`backend`, `infra`, `all`, or individual services).
- Supports `--no-build` flag to skip builds during service startup or restart.
- Applies `core` and `infra` profiles by default when no specific services are passed.
- Validates service names and provides clear error/help messages.
- Integrates with `build-services.sh` for targeted image building.
- Supports selective service actions: `start user-service infra`, `stop infra gateway`.
- Run `./run-services.sh` or `./run-services.sh -h` for documentation.
- Supports duplicate services: `start infra mailhog user-dev-db` will start `mailhog` and `user-dev-db` instead of throwing errors.

### Related Issue
Closes #185 
<!-- If this PR addresses an issue, please link to it here (e.g., `#123`). -->
<!-- related to #4, closes #9 -->

### Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Chore (maintenance, refactoring, etc.)
- [ ] Other (please describe):

### Checklist

<!-- Please check the items that apply and make sure to complete them before submitting your PR. -->

- [x] I have tested my changes.
- [ ] I have updated the documentation (if necessary).
- [ ] I have added necessary tests (if applicable).

### Screenshots/videos (if applicable)

<!-- If your changes include visual updates, please include screenshots/gifs/videos here. -->

### Additional Context

<!-- Any other information or context that is helpful to understand your changes (e.g., implementation details, reasoning,
etc.). -->
