### PR TITLE
fixed sonar project name issue

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -15,7 +15,7 @@
   <component name="ProjectResources">
     <resource url="https://checkstyle.org/dtds/suppressions_1_2.dtd" location="$PROJECT_DIR$/apps/backend/" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" project-jdk-name="temurin-17" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="temurin-17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <sonar.projectName>byte-bandit</sonar.projectName>
         <sonar.organization>learnathon-by-geeky-solutions</sonar.organization>
         <sonar.projectKey>Learnathon-By-Geeky-Solutions_byte-bandit</sonar.projectKey>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>


### PR DESCRIPTION
### Description
Currently in sonarcloud org, `oakcan` is being shown as project name. Fixed that by adding `<sonar.projectName>` at project pom.xml.

### Related Issue

<!-- If this PR addresses an issue, please link to it here (e.g., `#123`). -->
<!-- related to #4, closes #9 -->

### Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Chore (maintenance, refactoring, etc.)
- [ ] Other (please describe):

### Checklist

<!-- Please check the items that apply and make sure to complete them before submitting your PR. -->

- [ ] I have tested my changes.
- [ ] I have updated the documentation (if necessary).
- [ ] I have added necessary tests (if applicable).

### Screenshots/videos (if applicable)

<!-- If your changes include visual updates, please include screenshots/gifs/videos here. -->

### Additional Context

<!-- Any other information or context that is helpful to understand your changes (e.g., implementation details, reasoning,
etc.). -->
