### PR TITLE
fix: Fixed wildcard return type from register method to

### DIFF
--- a/apps/backend/user-service/src/main/java/com/bytebandit/userservice/controller/UserRegistrationController.java
+++ b/apps/backend/user-service/src/main/java/com/bytebandit/userservice/controller/UserRegistrationController.java
@@ -27,7 +27,9 @@ public class UserRegistrationController {
      */
     
     @PostMapping("/register")
-    ResponseEntity<?> register(@Valid @RequestBody UserRegistrationRequest request) {
+    ResponseEntity<ApiResponse<UserRegistrationResponse>> register(
+        @Valid @RequestBody UserRegistrationRequest request
+    ) {
         return ResponseEntity.ok(ApiResponse.<UserRegistrationResponse>builder()
             .data(userRegistrationService.register(request))
             .message("User registered successfully")


### PR DESCRIPTION
### Description

@voidCounter, i have checked client's `/app/register/page.tsx`, and saw you are accepting `ApiSuccessResponse<UserRegistrationResponse>`, i have changed it from wildcard (`?`) to `ApiResponse<UserRegistrationResponse>`
![image](https://github.com/user-attachments/assets/8f940f15-caa7-40d5-97a4-da7c7ad4aa9f)


### Related Issue

<!-- If this PR addresses an issue, please link to it here (e.g., `#123`). -->
<!-- related to #4, closes #9 -->

### Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Chore (maintenance, refactoring, etc.)
- [ ] Other (please describe):

### Checklist

<!-- Please check the items that apply and make sure to complete them before submitting your PR. -->

- [ ] I have tested my changes.
- [ ] I have updated the documentation (if necessary).
- [ ] I have added necessary tests (if applicable).

### Screenshots/videos (if applicable)

<!-- If your changes include visual updates, please include screenshots/gifs/videos here. -->

### Additional Context

<!-- Any other information or context that is helpful to understand your changes (e.g., implementation details, reasoning,
etc.). -->
