### PR TITLE
feat: added utility service `RoleBasedAccessControlService` for role based access

### DIFF
--- a/apps/backend/common/core/src/main/java/lib/core/validation/EnumValidator.java
+++ b/apps/backend/common/core/src/main/java/lib/core/validation/EnumValidator.java
@@ -2,7 +2,11 @@ package lib.core.validation;
 
 import jakarta.validation.Constraint;
 import jakarta.validation.Payload;
-import java.lang.annotation.*;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 @Target({ElementType.FIELD})
 @Retention(RetentionPolicy.RUNTIME)
@@ -10,11 +14,31 @@ import java.lang.annotation.*;
 @Documented
 public @interface EnumValidator {
 
-    Class<? extends Enum<?>> enumClass();
+    /**
+     * The enum class to validate against.
+     *
+     * @return the enum class
+     */
+    Class<?> enumClass();
 
+    /**
+     * The message to be returned if the validation fails.
+     *
+     * @return the error message
+     */
     String message() default "must be any of enum {enumClass}";
 
+    /**
+     * The groups the constraint belongs to.
+     *
+     * @return the groups
+     */
     Class<?>[] groups() default {};
 
+    /**
+     * The payload to be carried with the annotation.
+     *
+     * @return the payload
+     */
     Class<? extends Payload>[] payload() default {};
 }

--- a/apps/backend/common/core/src/main/java/lib/core/validation/EnumValidator.java
+++ b/apps/backend/common/core/src/main/java/lib/core/validation/EnumValidator.java
@@ -1,0 +1,20 @@
+package lib.core.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.*;
+
+@Target({ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = EnumValidatorImpl.class)
+@Documented
+public @interface EnumValidator {
+
+    Class<? extends Enum<?>> enumClass();
+
+    String message() default "must be any of enum {enumClass}";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/apps/backend/common/core/src/main/java/lib/core/validation/EnumValidatorImpl.java
+++ b/apps/backend/common/core/src/main/java/lib/core/validation/EnumValidatorImpl.java
@@ -1,0 +1,25 @@
+package lib.core.validation;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import java.util.Arrays;
+
+public class EnumValidatorImpl implements ConstraintValidator<EnumValidator, String> {
+
+    private EnumValidator annotation;
+
+    @Override
+    public void initialize(EnumValidator constraintAnnotation) {
+        this.annotation = constraintAnnotation;
+    }
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        if (value == null) {
+            return true;
+        }
+        Object[] enumValues = annotation.enumClass().getEnumConstants();
+        return Arrays.stream(enumValues)
+            .anyMatch(e -> e.toString().equalsIgnoreCase(value));
+    }
+}

--- a/apps/backend/file-service/src/main/java/com/bytebandit/fileservice/controller/CreateItemController.java
+++ b/apps/backend/file-service/src/main/java/com/bytebandit/fileservice/controller/CreateItemController.java
@@ -1,0 +1,37 @@
+package com.bytebandit.fileservice.controller;
+
+import static com.bytebandit.fileservice.utils.HttpHeaderUtils.getUserIdHeader;
+
+import com.bytebandit.fileservice.dto.CreateItemRequest;
+import com.bytebandit.fileservice.dto.CreateItemResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import java.util.UUID;
+import lib.core.dto.response.ApiResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/create")
+public class CreateItemController {
+
+    /**
+     * Creates a new file system item.
+     */
+    @PostMapping
+    public ResponseEntity<ApiResponse<CreateItemResponse>> createItem(
+        @Valid @RequestBody CreateItemRequest request,
+        @NotNull HttpServletRequest servletRequest
+    ) {
+        request.setOwnerId(
+            UUID.fromString(
+                getUserIdHeader(servletRequest)
+            )
+        );
+        return null; // to do
+    }
+}

--- a/apps/backend/file-service/src/main/java/com/bytebandit/fileservice/controller/PrivateShareController.java
+++ b/apps/backend/file-service/src/main/java/com/bytebandit/fileservice/controller/PrivateShareController.java
@@ -1,14 +1,14 @@
 package com.bytebandit.fileservice.controller;
 
+import static com.bytebandit.fileservice.utils.HttpHeaderUtils.getUserIdHeader;
+
 import com.bytebandit.fileservice.dto.ItemSharePrivateRequest;
 import com.bytebandit.fileservice.dto.ItemSharePrivateResponse;
-import com.bytebandit.fileservice.exception.UnauthenticatedException;
 import com.bytebandit.fileservice.service.PrivatePermissionService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import lib.core.dto.response.ApiResponse;
-import lib.core.enums.CustomHttpHeader;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -35,15 +35,7 @@ public class PrivateShareController {
         @NotNull HttpServletRequest servletRequest
     ) {
 
-        String userIdHeader = servletRequest.getHeader(CustomHttpHeader.USER_ID.getValue());
-
-        if (userIdHeader == null) {
-            throw new UnauthenticatedException("User ID header is missing");
-        }
-
-        log.info("Shared by user id : {}", userIdHeader);
-
-        request.setSharedByUserId(userIdHeader);
+        request.setSharedByUserId(getUserIdHeader(servletRequest));
         ItemSharePrivateResponse permissionResponse =
             privatePermissionService.givePermissionToUsers(request);
 

--- a/apps/backend/file-service/src/main/java/com/bytebandit/fileservice/dto/Chunks.java
+++ b/apps/backend/file-service/src/main/java/com/bytebandit/fileservice/dto/Chunks.java
@@ -1,0 +1,14 @@
+package com.bytebandit.fileservice.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class Chunks {
+
+    @NotBlank
+    private String id;
+
+    @NotBlank
+    private String status;
+}

--- a/apps/backend/file-service/src/main/java/com/bytebandit/fileservice/dto/CreateItemRequest.java
+++ b/apps/backend/file-service/src/main/java/com/bytebandit/fileservice/dto/CreateItemRequest.java
@@ -1,0 +1,39 @@
+package com.bytebandit.fileservice.dto;
+
+import com.bytebandit.fileservice.enums.FileSystemItemType;
+import com.bytebandit.fileservice.validator.ValidId;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import java.math.BigInteger;
+import java.util.UUID;
+import lib.core.validation.EnumValidator;
+import lombok.Data;
+
+@Data
+public class CreateItemRequest {
+
+    @Valid
+    private Chunks chunks;
+
+    private String mimeType;
+
+    @NotBlank
+    private String name;
+
+    private UUID ownerId;
+
+    private String s3Url;
+
+    private String status;
+
+    @EnumValidator(
+        enumClass = FileSystemItemType.class,
+        message = "Invalid file system item type."
+    )
+    private String type;
+
+    private BigInteger size;
+
+    @ValidId
+    private String parentId;
+}

--- a/apps/backend/file-service/src/main/java/com/bytebandit/fileservice/dto/CreateItemResponse.java
+++ b/apps/backend/file-service/src/main/java/com/bytebandit/fileservice/dto/CreateItemResponse.java
@@ -1,0 +1,23 @@
+package com.bytebandit.fileservice.dto;
+
+import java.math.BigInteger;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CreateItemResponse {
+
+    private String itemId;
+    private String name;
+    private String createdAt;
+    private String updatedAt;
+    private BigInteger fileSize;
+    private String status;
+    private String type;
+    private String parentId;
+}

--- a/apps/backend/file-service/src/main/java/com/bytebandit/fileservice/model/FileSystemItemEntity.java
+++ b/apps/backend/file-service/src/main/java/com/bytebandit/fileservice/model/FileSystemItemEntity.java
@@ -27,6 +27,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.annotations.UpdateTimestamp;
 import org.hibernate.type.SqlTypes;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -71,6 +72,9 @@ public class FileSystemItemEntity {
     @CreationTimestamp
     @Column(updatable = false)
     private Timestamp createdAt;
+
+    @UpdateTimestamp
+    private Timestamp updatedAt;
 
     @Column(nullable = false)
     private String s3Url;

--- a/apps/backend/file-service/src/main/java/com/bytebandit/fileservice/model/SharedItemsPublicEntity.java
+++ b/apps/backend/file-service/src/main/java/com/bytebandit/fileservice/model/SharedItemsPublicEntity.java
@@ -1,6 +1,7 @@
 package com.bytebandit.fileservice.model;
 
 import com.bytebandit.fileservice.enums.FileSystemPermission;
+import jakarta.annotation.Nullable;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -51,6 +52,9 @@ public class SharedItemsPublicEntity {
     @UpdateTimestamp
     @Column(nullable = false)
     private Timestamp updatedAt;
+
+    @Column(nullable = false)
+    private Timestamp expiresAt;
 
     @OneToOne
     @JoinColumn(

--- a/apps/backend/file-service/src/main/java/com/bytebandit/fileservice/repository/FileSystemItemRepository.java
+++ b/apps/backend/file-service/src/main/java/com/bytebandit/fileservice/repository/FileSystemItemRepository.java
@@ -10,6 +10,13 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface FileSystemItemRepository extends JpaRepository<FileSystemItemEntity, UUID> {
 
+    /**
+     * Get the permission of a file system item recursively.
+     *
+     * @param inputItemId the ID of the item
+     * @param inputUserId the ID of the user
+     * @return the permission string
+     */
     @Query(
         value = "SELECT * FROM get_permission_recursive("
             + "CAST(:input_item_id AS UUID), "

--- a/apps/backend/file-service/src/main/java/com/bytebandit/fileservice/repository/FileSystemItemRepository.java
+++ b/apps/backend/file-service/src/main/java/com/bytebandit/fileservice/repository/FileSystemItemRepository.java
@@ -3,8 +3,22 @@ package com.bytebandit.fileservice.repository;
 import com.bytebandit.fileservice.model.FileSystemItemEntity;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface FileSystemItemRepository extends JpaRepository<FileSystemItemEntity, UUID> {
+
+    @Query(
+        value = "SELECT * FROM get_permission_recursive("
+            + "CAST(:input_item_id AS UUID), "
+            + "CAST(:input_user_id AS UUID)"
+            + ")",
+        nativeQuery = true
+    )
+    String getPermissionRecursive(
+        @Param("input_item_id") UUID inputItemId,
+        @Param("input_user_id") UUID inputUserId
+    );
 }

--- a/apps/backend/file-service/src/main/java/com/bytebandit/fileservice/service/CreateItemService.java
+++ b/apps/backend/file-service/src/main/java/com/bytebandit/fileservice/service/CreateItemService.java
@@ -1,0 +1,23 @@
+package com.bytebandit.fileservice.service;
+
+import com.bytebandit.fileservice.dto.CreateItemRequest;
+import com.bytebandit.fileservice.dto.CreateItemResponse;
+import com.bytebandit.fileservice.repository.FileSystemItemRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CreateItemService {
+
+    private final FileSystemItemRepository fileSystemItemRepository;
+
+    /**
+     * Creates a new file system item.
+     */
+    public CreateItemResponse createItem(
+        CreateItemRequest createItemRequest
+    ) {
+        return null; // to do
+    }
+}

--- a/apps/backend/file-service/src/main/java/com/bytebandit/fileservice/service/RoleBasedAccessControlService.java
+++ b/apps/backend/file-service/src/main/java/com/bytebandit/fileservice/service/RoleBasedAccessControlService.java
@@ -1,0 +1,18 @@
+package com.bytebandit.fileservice.service;
+
+import com.bytebandit.fileservice.repository.FileSystemItemRepository;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RoleBasedAccessControlService {
+
+    private final FileSystemItemRepository fileSystemItemRepository;
+
+    public String getPermission(String itemId, UUID userId) {
+        return fileSystemItemRepository.getPermissionRecursive(
+            UUID.fromString(itemId), userId);
+    }
+}

--- a/apps/backend/file-service/src/main/java/com/bytebandit/fileservice/utils/HttpHeaderUtils.java
+++ b/apps/backend/file-service/src/main/java/com/bytebandit/fileservice/utils/HttpHeaderUtils.java
@@ -1,0 +1,40 @@
+package com.bytebandit.fileservice.utils;
+
+import com.bytebandit.fileservice.exception.UnauthenticatedException;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.UUID;
+import lib.core.enums.CustomHttpHeader;
+
+public class HttpHeaderUtils {
+
+    private HttpHeaderUtils() {
+    }
+
+    /**
+     * Retrieves the user ID from the request header.
+     *
+     * @param servletRequest the HTTP servlet request
+     *
+     * @return the user ID from the header
+     * @throws UnauthenticatedException if the user ID header is missing
+     */
+    public static String getUserIdHeader(HttpServletRequest servletRequest) {
+        String userIdHeader = servletRequest.getHeader(CustomHttpHeader.USER_ID.getValue());
+
+        if (userIdHeader == null) {
+            throwError();
+        }
+
+        try {
+            UUID.fromString(userIdHeader);
+        } catch (IllegalArgumentException ex) {
+            throwError();
+        }
+
+        return userIdHeader;
+    }
+
+    private static void throwError() {
+        throw new UnauthenticatedException("User ID header is missing");
+    }
+}

--- a/apps/backend/file-service/src/main/resources/schema.sql
+++ b/apps/backend/file-service/src/main/resources/schema.sql
@@ -77,3 +77,90 @@ BEGIN
     RETURN result_permissions;
 END;
 ' LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION get_permission_recursive(
+    input_item_id UUID,
+    input_user_id UUID
+)
+    RETURNS TEXT AS '
+DECLARE
+    current_item_id UUID := input_item_id;
+    permission_level TEXT := ''NO_ACCESS'';
+    owner_check BOOLEAN;
+    found_permission TEXT;
+BEGIN
+    WHILE current_item_id IS NOT NULL LOOP
+            -- Check for ownership at the current level
+            SELECT CASE
+                       WHEN COUNT(*) > 0 THEN TRUE
+                       ELSE FALSE
+                       END
+            INTO owner_check
+            FROM file_system_items
+            WHERE id = current_item_id AND owner = input_user_id;
+
+            IF owner_check THEN
+                RETURN ''OWNER'';
+            END IF;
+
+            -- Check for EDITOR permission in private shares at the current level
+            SELECT isp.permission INTO found_permission
+            FROM shared_items_private isp
+            WHERE isp.item_id = current_item_id
+              AND isp.shared_with = input_user_id
+              AND isp.permission = ''EDITOR'';
+
+            IF FOUND THEN
+                IF permission_level = ''NO_ACCESS'' OR permission_level = ''VIEWER'' THEN
+                    permission_level := ''EDITOR'';
+                END IF;
+            END IF;
+
+            -- Check for EDITOR permission in public shares at the current level
+            SELECT isp.permission INTO found_permission
+            FROM shared_items_public isp
+            WHERE isp.item_id = current_item_id
+              AND isp.permission = ''EDITOR''
+              AND (isp.expires_at IS NULL OR isp.expires_at > NOW());
+
+            IF FOUND THEN
+                IF permission_level = ''NO_ACCESS'' OR permission_level = ''VIEWER'' THEN
+                    permission_level := ''EDITOR'';
+                END IF;
+            END IF;
+
+            -- Check for VIEWER permission in private shares at the current level
+            SELECT isp.permission INTO found_permission
+            FROM shared_items_private isp
+            WHERE isp.item_id = current_item_id
+              AND isp.shared_with = input_user_id
+              AND isp.permission = ''VIEWER'';
+
+            IF FOUND THEN
+                IF permission_level = ''NO_ACCESS'' THEN
+                    permission_level := ''VIEWER'';
+                END IF;
+            END IF;
+
+            -- Check for VIEWER permission in public shares at the current level
+            SELECT isp.permission INTO found_permission
+            FROM shared_items_public isp
+            WHERE isp.item_id = current_item_id
+              AND isp.permission = ''VIEWER''
+              AND (isp.expires_at IS NULL OR isp.expires_at > NOW());
+
+            IF FOUND THEN
+                IF permission_level = ''NO_ACCESS'' THEN
+                    permission_level := ''VIEWER'';
+                END IF;
+            END IF;
+
+            -- Move to the parent item
+            SELECT parent_id INTO current_item_id
+            FROM file_system_items
+            WHERE id = current_item_id;
+        END LOOP;
+
+    RETURN permission_level;
+END;
+' LANGUAGE plpgsql;

--- a/apps/backend/file-service/src/test/java/com/bytebandit/fileservice/repository/SharedItemsPublicRepository.java
+++ b/apps/backend/file-service/src/test/java/com/bytebandit/fileservice/repository/SharedItemsPublicRepository.java
@@ -1,0 +1,10 @@
+package com.bytebandit.fileservice.repository;
+
+import com.bytebandit.fileservice.model.SharedItemsPublicEntity;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SharedItemsPublicRepository extends
+    JpaRepository<SharedItemsPublicEntity, UUID> { }

--- a/apps/backend/file-service/src/test/java/com/bytebandit/fileservice/service/RoleBasedAccessControlServiceIT.java
+++ b/apps/backend/file-service/src/test/java/com/bytebandit/fileservice/service/RoleBasedAccessControlServiceIT.java
@@ -1,0 +1,195 @@
+package com.bytebandit.fileservice.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import com.bytebandit.fileservice.configurer.AbstractPostgresContainer;
+import com.bytebandit.fileservice.enums.FileSystemItemType;
+import com.bytebandit.fileservice.enums.FileSystemPermission;
+import com.bytebandit.fileservice.enums.UploadStatus;
+import com.bytebandit.fileservice.model.FileSystemItemEntity;
+import com.bytebandit.fileservice.model.SharedItemsPrivateEntity;
+import com.bytebandit.fileservice.model.SharedItemsPublicEntity;
+import com.bytebandit.fileservice.repository.FileSystemItemRepository;
+import com.bytebandit.fileservice.repository.SharedItemsPrivateRepository;
+import com.bytebandit.fileservice.repository.SharedItemsPublicRepository;
+import io.restassured.RestAssured;
+import jakarta.transaction.Transactional;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.context.ActiveProfiles;
+
+@Slf4j
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ActiveProfiles("test")
+class RoleBasedAccessControlServiceIT extends AbstractPostgresContainer {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private FileSystemItemRepository fileSystemItemRepository;
+
+    @Autowired
+    private SharedItemsPrivateRepository sharedItemsPrivateRepository;
+
+    @Autowired
+    private SharedItemsPublicRepository sharedItemsPublicRepository;
+
+    @Autowired
+    private RoleBasedAccessControlService permissionService;
+
+    private UUID ownerId;
+    private UUID otherUserId;
+
+    /**
+     * Constructor for RoleBasedAccessControlServiceIT.
+     */
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+        sharedItemsPrivateRepository.deleteAll();
+        sharedItemsPublicRepository.deleteAll();
+        fileSystemItemRepository.deleteAll();
+        ownerId = UUID.randomUUID();
+        otherUserId = UUID.randomUUID();
+    }
+
+    /**
+     * Test for getPermission method.
+     */
+    @Test
+    @Transactional
+    void shouldReturnOwnerPermissionWhenUserIsOwner() {
+        FileSystemItemEntity item = new FileSystemItemEntity();
+        item.setName("Test File");
+        item.setSize(100L);
+        item.setMimeType("text/plain");
+        item.setOwner(ownerId);
+        item.setStatus(UploadStatus.NOT_UPLOADED);
+        item.setType(FileSystemItemType.FILE);
+        item.setS3Url("s3://test-bucket/test-file");
+        item = fileSystemItemRepository.save(item);
+
+        String permission = permissionService.getPermission(item.getId().toString(), ownerId);
+
+        assertThat(permission).isEqualTo("OWNER");
+    }
+
+    /**
+     * Test for getPermission method when user is not the owner.
+     */
+    @Test
+    @Transactional
+    void shouldReturnEditorPermissionWhenUserHasPrivateEditorShare() {
+        FileSystemItemEntity item = new FileSystemItemEntity();
+        item.setName("Shared File");
+        item.setSize(200L);
+        item.setMimeType("application/pdf");
+        item.setOwner(UUID.randomUUID());
+        item.setStatus(UploadStatus.NOT_UPLOADED);
+        item.setType(FileSystemItemType.FILE);
+        item.setS3Url("s3://test-bucket/shared-file");
+        item = fileSystemItemRepository.save(item);
+
+        SharedItemsPrivateEntity privateShare = new SharedItemsPrivateEntity();
+        privateShare.setItem(item);
+        privateShare.setUserId(item.getOwner());
+        privateShare.setSharedWith(otherUserId);
+        privateShare.setPermission(FileSystemPermission.EDITOR);
+        sharedItemsPrivateRepository.save(privateShare);
+
+        String permission = permissionService.getPermission(item.getId().toString(), otherUserId);
+
+        assertThat(permission).isEqualTo("EDITOR");
+    }
+
+    /**
+     * Test for getPermission method when user has viewer permission.
+     */
+    @Test
+    @Transactional
+    void shouldReturnViewerPermissionWhenUserHasPrivateViewerShare() {
+        FileSystemItemEntity item = new FileSystemItemEntity();
+        item.setName("Viewer Shared File");
+        item.setSize(300L);
+        item.setMimeType("image/jpeg");
+        item.setOwner(UUID.randomUUID());
+        item.setStatus(UploadStatus.NOT_UPLOADED);
+        item.setType(FileSystemItemType.FILE);
+        item.setS3Url("s3://test-bucket/viewer-file");
+        item = fileSystemItemRepository.save(item);
+
+        SharedItemsPrivateEntity privateShare = new SharedItemsPrivateEntity();
+        privateShare.setItem(item);
+        privateShare.setUserId(item.getOwner());
+        privateShare.setSharedWith(otherUserId);
+        privateShare.setPermission(FileSystemPermission.VIEWER);
+        sharedItemsPrivateRepository.save(privateShare);
+
+        String permission = permissionService.getPermission(item.getId().toString(), otherUserId);
+
+        assertThat(permission).isEqualTo("VIEWER");
+    }
+
+    /**
+     * Test for getPermission method when user has no permission.
+     */
+    @Test
+    @Transactional
+    void shouldReturnNoAccessWhenUserHasNoPermission() {
+        FileSystemItemEntity item = new FileSystemItemEntity();
+        item.setName("Private File");
+        item.setSize(400L);
+        item.setMimeType("application/zip");
+        item.setOwner(UUID.randomUUID());
+        item.setStatus(UploadStatus.NOT_UPLOADED);
+        item.setType(FileSystemItemType.FILE);
+        item.setS3Url("s3://test-bucket/private-file");
+        item = fileSystemItemRepository.save(item);
+
+        String permission = permissionService.getPermission(item.getId().toString(), otherUserId);
+
+        assertThat(permission).isEqualTo("NO_ACCESS");
+    }
+
+    /**
+     * Test for getPermission method when user has public share.
+     */
+    @Test
+    @Transactional
+    void shouldReturnEditorPermissionFromPublicShare() {
+        FileSystemItemEntity item = new FileSystemItemEntity();
+        item.setName("Public Shared File");
+        item.setSize(500L);
+        item.setMimeType("application/msword");
+        item.setOwner(UUID.randomUUID());
+        item.setStatus(UploadStatus.UPLOADED);
+        item.setType(FileSystemItemType.FILE);
+        item.setS3Url("s3://test-bucket/public-shared-file");
+        item = fileSystemItemRepository.save(item);
+
+        SharedItemsPublicEntity publicShare = new SharedItemsPublicEntity();
+        publicShare.setItem(item);
+        publicShare.setPermission(FileSystemPermission.EDITOR);
+        publicShare.setSharedBy(item.getOwner());
+        publicShare.setPasswordHash("dummyhash");
+        publicShare.setExpiresAt(Timestamp.from(Instant.now().plusSeconds(3600)));
+        sharedItemsPublicRepository.save(publicShare);
+
+        String permission = permissionService.getPermission(item.getId().toString(), otherUserId);
+
+        assertThat(permission).isEqualTo("EDITOR");
+    }
+}


### PR DESCRIPTION
### Description

- Added a sql routing `get_permission_recurisive` that determines the permission recursively of an itemId user wants to access
- Added tests for `RoleBasedAccessControlService`

### Related Issue

<!-- If this PR addresses an issue, please link to it here (e.g., `#123`). -->
<!-- related to #4, closes #9 -->

### Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Chore (maintenance, refactoring, etc.)
- [ ] Other (please describe):

### Checklist

<!-- Please check the items that apply and make sure to complete them before submitting your PR. -->

- [x] I have tested my changes.
- [ ] I have updated the documentation (if necessary).
- [ ] I have added necessary tests (if applicable).

### Screenshots/videos (if applicable)

<!-- If your changes include visual updates, please include screenshots/gifs/videos here. -->

### Additional Context

<!-- Any other information or context that is helpful to understand your changes (e.g., implementation details, reasoning,
etc.). -->
