### PR TITLE
Feat: enabled password protection and password validation in the public sharing

### DIFF
--- a/apps/backend/common/core/src/main/java/lib/core/enums/ErrorCode.java
+++ b/apps/backend/common/core/src/main/java/lib/core/enums/ErrorCode.java
@@ -19,6 +19,9 @@ public enum ErrorCode {
     PERMISSION_DENIED("PERM-01", "You do not have permission to access this resource."),
     ITEM_NOT_FOUND("ITEM-01", "Item not found."),
     ITEM_VIEW_ERROR("ITEM-02", "Error occurred while viewing the item."),
+    ITEM_PROTECTED_WITH_PASSWORD("ITEM-03","Trying to access protected item"
+        + " without providing password."),
+    ITEM_WRONG_PASSWORD("ITEM-04", "Wrong password provided for the item."),
     
     DATABASE_ERROR("DB-02", "Database error occurred."),
     
@@ -57,7 +60,7 @@ public enum ErrorCode {
     PRIVATE_SHARE_ERROR("SHARE-02", "Error occurred while sharing the file privately."),
     
     UNKNOWN_ERROR("UNKNOWN", "An unknown error has occurred.");
-    
+
     private final String code;
     private final String message;
 }

--- a/apps/backend/file-service/src/main/java/com/bytebandit/fileservice/exception/GlobalExceptionHandler.java
+++ b/apps/backend/file-service/src/main/java/com/bytebandit/fileservice/exception/GlobalExceptionHandler.java
@@ -47,7 +47,15 @@ public class GlobalExceptionHandler {
             ex.getMessage());
     }
 
-
+    /**
+     * Handles ItemPasswordVerificationFailedException and returns a ResponseEntity with an error
+     * response.
+     *
+     * @param ex      the ItemPasswordVerificationFailedException to handle
+     * @param request the HttpServletRequest object
+     *
+     * @return a ResponseEntity with an error response
+     */
     @ExceptionHandler(UnauthenticatedException.class)
     public ResponseEntity<ErrorResponse> handleUnauthenticatedException(
         UnauthenticatedException ex, HttpServletRequest request) {
@@ -55,6 +63,15 @@ public class GlobalExceptionHandler {
             ex.getMessage());
     }
 
+    /**
+     * Handles ItemPasswordVerificationFailedException and returns a ResponseEntity with an error
+     * response.
+     *
+     * @param ex      the ItemPasswordVerificationFailedException to handle
+     * @param request the HttpServletRequest object
+     *
+     * @return a ResponseEntity with an error response
+     */
     @ExceptionHandler(NotEnoughPermissionException.class)
     public ResponseEntity<ErrorResponse> handleNotEnoughPermissionException(
         NotEnoughPermissionException ex, HttpServletRequest request) {
@@ -62,6 +79,15 @@ public class GlobalExceptionHandler {
             ex.getMessage());
     }
 
+    /**
+     * Handles ItemPasswordVerificationFailedException and returns a ResponseEntity with an error
+     * response.
+     *
+     * @param ex      the ItemPasswordVerificationFailedException to handle
+     * @param request the HttpServletRequest object
+     *
+     * @return a ResponseEntity with an error response
+     */
     @ExceptionHandler(ItemNotFoundException.class)
     public ResponseEntity<ErrorResponse> handleItemNotFoundException(
         ItemNotFoundException ex, HttpServletRequest request) {
@@ -69,6 +95,15 @@ public class GlobalExceptionHandler {
             ex.getMessage());
     }
 
+    /**
+     * Handles ItemPasswordVerificationFailedException and returns a ResponseEntity with an error
+     * response.
+     *
+     * @param ex      the ItemPasswordVerificationFailedException to handle
+     * @param request the HttpServletRequest object
+     *
+     * @return a ResponseEntity with an error response
+     */
     @ExceptionHandler(UserNotFoundException.class)
     public ResponseEntity<ErrorResponse> handleUserNotFoundException(
         UserNotFoundException ex, HttpServletRequest request) {
@@ -76,10 +111,53 @@ public class GlobalExceptionHandler {
             ex.getMessage());
     }
 
+    /**
+     * Handles ItemPasswordVerificationFailedException and returns a ResponseEntity with an error
+     * response.
+     *
+     * @param ex      the ItemPasswordVerificationFailedException to handle
+     * @param request the HttpServletRequest object
+     *
+     * @return a ResponseEntity with an error response
+     */
     @ExceptionHandler(ItemViewException.class)
     public ResponseEntity<ErrorResponse> handleItemViewException(
         ItemViewException ex, HttpServletRequest request) {
         return buildResponse(HttpStatus.NOT_FOUND, ErrorCode.ITEM_VIEW_ERROR, request,
+            ex.getMessage());
+    }
+
+    /**
+     * Handles ItemPasswordVerificationFailedException and returns a ResponseEntity with an error
+     * response.
+     *
+     * @param ex      the ItemPasswordVerificationFailedException to handle
+     * @param request the HttpServletRequest object
+     *
+     * @return a ResponseEntity with an error response
+     */
+    @ExceptionHandler(ItemProtectedWithPasswordException.class)
+    public ResponseEntity<ErrorResponse> handleItemProtectedWithPasswordException(
+        ItemProtectedWithPasswordException ex, HttpServletRequest request) {
+        return buildResponse(HttpStatus.FORBIDDEN, ErrorCode.ITEM_PROTECTED_WITH_PASSWORD,
+            request,
+            ex.getMessage());
+    }
+
+    /**
+     * Handles ItemPasswordVerificationFailedException and returns a ResponseEntity with an error
+     * response.
+     *
+     * @param ex      the ItemPasswordVerificationFailedException to handle
+     * @param request the HttpServletRequest object
+     *
+     * @return a ResponseEntity with an error response
+     */
+    @ExceptionHandler(ItemPasswordVerificationFailedException.class)
+    public ResponseEntity<ErrorResponse> handleItemPasswordVerificationFailedException(
+        ItemPasswordVerificationFailedException ex, HttpServletRequest request) {
+        return buildResponse(HttpStatus.FORBIDDEN, ErrorCode.ITEM_WRONG_PASSWORD,
+            request,
             ex.getMessage());
     }
 

--- a/apps/backend/file-service/src/main/java/com/bytebandit/fileservice/exception/ItemPasswordVerificationFailedException.java
+++ b/apps/backend/file-service/src/main/java/com/bytebandit/fileservice/exception/ItemPasswordVerificationFailedException.java
@@ -1,0 +1,7 @@
+package com.bytebandit.fileservice.exception;
+
+public class ItemPasswordVerificationFailedException extends RuntimeException {
+    public ItemPasswordVerificationFailedException(String message) {
+        super(message);
+    }
+}

--- a/apps/backend/file-service/src/main/java/com/bytebandit/fileservice/exception/ItemProtectedWithPasswordException.java
+++ b/apps/backend/file-service/src/main/java/com/bytebandit/fileservice/exception/ItemProtectedWithPasswordException.java
@@ -1,0 +1,7 @@
+package com.bytebandit.fileservice.exception;
+
+public class ItemProtectedWithPasswordException extends RuntimeException {
+    public ItemProtectedWithPasswordException(String message) {
+        super(message);
+    }
+}

--- a/apps/backend/file-service/src/main/java/com/bytebandit/fileservice/repository/SharedItemsPublicRepository.java
+++ b/apps/backend/file-service/src/main/java/com/bytebandit/fileservice/repository/SharedItemsPublicRepository.java
@@ -27,5 +27,5 @@ public interface SharedItemsPublicRepository extends JpaRepository<SharedItemsPu
 
     SharedItemsPublicEntity findByItemId(UUID uuid);
 
-    SharedItemsPublicEntity findByItemIdAndExpiresAtIsBefore(UUID itemId, Timestamp from);
+    SharedItemsPublicEntity findByItemIdAndExpiresAtAfter(UUID itemId, Timestamp expiresAtAfter);
 }

--- a/apps/backend/file-service/src/main/java/com/bytebandit/fileservice/repository/SharedItemsPublicRepository.java
+++ b/apps/backend/file-service/src/main/java/com/bytebandit/fileservice/repository/SharedItemsPublicRepository.java
@@ -24,4 +24,8 @@ public interface SharedItemsPublicRepository extends JpaRepository<SharedItemsPu
         @Param("p_password_hash") String passwordHash,
         @Param("p_expires_at") Timestamp expiresAt
     );
+
+    SharedItemsPublicEntity findByItemId(UUID uuid);
+
+    SharedItemsPublicEntity findByItemIdAndExpiresAtIsBefore(UUID itemId, Timestamp from);
 }

--- a/apps/backend/file-service/src/main/java/com/bytebandit/fileservice/service/ItemViewService.java
+++ b/apps/backend/file-service/src/main/java/com/bytebandit/fileservice/service/ItemViewService.java
@@ -36,8 +36,23 @@ public class ItemViewService {
             itemViewRequest.getItemId(),
             userId
         ).toUpperCase();
+
+        log.info("permission: {}", permission);
+
         if (permission.equals("NO_ACCESS")) {
             throw new ItemViewException("You do not have access to this item.");
+        }
+
+        boolean isAccessible = permission.equals("OWNER")
+            || !roleBasedAccessControlService.isPasswordProtected(itemViewRequest.getItemId());
+
+        log.info("protected? {}", isAccessible);
+
+        if (!isAccessible) {
+            roleBasedAccessControlService.validatePassword(
+                UUID.fromString(itemViewRequest.getItemId()),
+                itemViewRequest.getPassword()
+            );
         }
 
         try {

--- a/apps/backend/file-service/src/main/java/com/bytebandit/fileservice/service/RoleBasedAccessControlService.java
+++ b/apps/backend/file-service/src/main/java/com/bytebandit/fileservice/service/RoleBasedAccessControlService.java
@@ -1,18 +1,55 @@
 package com.bytebandit.fileservice.service;
 
+import com.bytebandit.fileservice.exception.ItemPasswordVerificationFailedException;
+import com.bytebandit.fileservice.exception.ItemProtectedWithPasswordException;
+import com.bytebandit.fileservice.model.SharedItemsPublicEntity;
 import com.bytebandit.fileservice.repository.FileSystemItemRepository;
+import com.bytebandit.fileservice.repository.SharedItemsPublicRepository;
+import java.sql.Timestamp;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class RoleBasedAccessControlService {
 
     private final FileSystemItemRepository fileSystemItemRepository;
+    private final SharedItemsPublicRepository sharedItemsPublicRepository;
+    private final PasswordEncoder passwordEncoder;
 
     public String getPermission(String itemId, UUID userId) {
         return fileSystemItemRepository.getPermissionRecursive(
             UUID.fromString(itemId), userId);
+    }
+
+    /**
+     * Check if an item is password protected.
+     */
+    public boolean isPasswordProtected(String itemId) {
+        return sharedItemsPublicRepository.findByItemId(
+                UUID.fromString(itemId)
+            ).getPasswordHash() != null;
+    }
+
+    /**
+     * Check if the provided password is correct.
+     */
+    public void validatePassword(UUID itemId, String password) {
+        if (password == null) {
+            throw new ItemProtectedWithPasswordException("The item you are trying to access is "
+                + "protected by  password");
+        }
+        SharedItemsPublicEntity publicShareItems =
+            sharedItemsPublicRepository.findByItemIdAndExpiresAtIsBefore(
+                itemId, Timestamp.from(Instant.now())
+            );
+        if (!passwordEncoder.matches(password, publicShareItems.getPasswordHash())) {
+            throw new ItemPasswordVerificationFailedException("Provided password is wrong");
+        }
     }
 }

--- a/apps/backend/file-service/src/main/java/com/bytebandit/fileservice/service/RoleBasedAccessControlService.java
+++ b/apps/backend/file-service/src/main/java/com/bytebandit/fileservice/service/RoleBasedAccessControlService.java
@@ -31,9 +31,10 @@ public class RoleBasedAccessControlService {
      * Check if an item is password protected.
      */
     public boolean isPasswordProtected(String itemId) {
-        return sharedItemsPublicRepository.findByItemId(
+        SharedItemsPublicEntity entity = sharedItemsPublicRepository.findByItemId(
                 UUID.fromString(itemId)
-            ).getPasswordHash() != null;
+            );
+        return entity != null && entity.getPasswordHash() != null;
     }
 
     /**
@@ -45,7 +46,7 @@ public class RoleBasedAccessControlService {
                 + "protected by  password");
         }
         SharedItemsPublicEntity publicShareItems =
-            sharedItemsPublicRepository.findByItemIdAndExpiresAtIsBefore(
+            sharedItemsPublicRepository.findByItemIdAndExpiresAtAfter(
                 itemId, Timestamp.from(Instant.now())
             );
         if (!passwordEncoder.matches(password, publicShareItems.getPasswordHash())) {

--- a/apps/backend/file-service/src/test/java/com/bytebandit/fileservice/service/RoleBasedAccessControlServiceIT.java
+++ b/apps/backend/file-service/src/test/java/com/bytebandit/fileservice/service/RoleBasedAccessControlServiceIT.java
@@ -1,11 +1,14 @@
 package com.bytebandit.fileservice.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 import com.bytebandit.fileservice.configurer.AbstractPostgresContainer;
 import com.bytebandit.fileservice.enums.FileSystemItemType;
 import com.bytebandit.fileservice.enums.FileSystemPermission;
 import com.bytebandit.fileservice.enums.UploadStatus;
+import com.bytebandit.fileservice.exception.ItemPasswordVerificationFailedException;
+import com.bytebandit.fileservice.exception.ItemProtectedWithPasswordException;
 import com.bytebandit.fileservice.model.FileSystemItemEntity;
 import com.bytebandit.fileservice.model.SharedItemsPrivateEntity;
 import com.bytebandit.fileservice.model.SharedItemsPublicEntity;
@@ -26,6 +29,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.test.context.ActiveProfiles;
 
 @Slf4j
@@ -224,4 +228,134 @@ class RoleBasedAccessControlServiceIT extends AbstractPostgresContainer {
 
         assertThat(permission).isEqualTo("EDITOR");
     }
+
+    /**
+     * Test for getPermission method when user has public share with viewer permission.
+     */
+    @Test
+    void shouldReturnTrueWhenItemIsPasswordProtected() {
+        FileSystemItemEntity item = createAndSaveFileItem();
+
+        SharedItemsPublicEntity publicShare = new SharedItemsPublicEntity();
+        publicShare.setItem(item);
+        publicShare.setPermission(FileSystemPermission.VIEWER);
+        publicShare.setSharedBy(item.getOwner());
+        publicShare.setPasswordHash("someHash");
+        publicShare.setExpiresAt(Timestamp.from(Instant.now().plusSeconds(3600)));
+        sharedItemsPublicRepository.save(publicShare);
+
+        boolean isProtected = permissionService.isPasswordProtected(item.getId().toString());
+        assertThat(isProtected).isTrue();
+    }
+
+    /**
+     * Test for getPermission method when user has public share with no password.
+     */
+    @Test
+    void shouldReturnFalseWhenItemIsNotSharedPublicly() {
+        FileSystemItemEntity item = createAndSaveFileItem();
+        boolean isProtected = permissionService.isPasswordProtected(item.getId().toString());
+        assertThat(isProtected).isFalse();
+    }
+
+    /**
+     * Test for getPermission method when user has public share with null password.
+     */
+    @Test
+    void shouldReturnFalseWhenPasswordHashIsNull() {
+        FileSystemItemEntity item = createAndSaveFileItem();
+
+        SharedItemsPublicEntity publicShare = new SharedItemsPublicEntity();
+        publicShare.setItem(item);
+        publicShare.setPermission(FileSystemPermission.VIEWER);
+        publicShare.setSharedBy(item.getOwner());
+        publicShare.setPasswordHash(null);
+        publicShare.setExpiresAt(Timestamp.from(Instant.now().plusSeconds(3600)));
+        sharedItemsPublicRepository.save(publicShare);
+
+        boolean isProtected = permissionService.isPasswordProtected(item.getId().toString());
+        assertThat(isProtected).isFalse();
+    }
+
+    /**
+     * Test for getPermission method when user has public share with null password.
+     */
+    @Test
+    void shouldThrowExceptionWhenPasswordIsNull() {
+        FileSystemItemEntity item = createAndSaveFileItem();
+
+        SharedItemsPublicEntity publicShare = new SharedItemsPublicEntity();
+        publicShare.setItem(item);
+        publicShare.setPermission(FileSystemPermission.VIEWER);
+        publicShare.setSharedBy(item.getOwner());
+        publicShare.setPasswordHash("hashedPassword");
+        publicShare.setExpiresAt(Timestamp.from(Instant.now().plusSeconds(3600)));
+        sharedItemsPublicRepository.save(publicShare);
+
+        assertThatThrownBy(() ->
+            permissionService.validatePassword(item.getId(), null)
+        ).isInstanceOf(ItemProtectedWithPasswordException.class)
+            .hasMessageContaining("protected by  password");
+    }
+
+    /**
+     * Test for getPermission method when user has public share with null password.
+     */
+    @Test
+    void shouldThrowExceptionWhenPasswordIsInvalid() {
+        FileSystemItemEntity item = createAndSaveFileItem();
+
+        String actualPassword = "correct-password";
+        String hash = new BCryptPasswordEncoder().encode(actualPassword);
+
+        SharedItemsPublicEntity publicShare = new SharedItemsPublicEntity();
+        publicShare.setItem(item);
+        publicShare.setPermission(FileSystemPermission.VIEWER);
+        publicShare.setSharedBy(item.getOwner());
+        publicShare.setPasswordHash(hash);
+        publicShare.setExpiresAt(Timestamp.from(Instant.now().plusSeconds(3600)));
+        sharedItemsPublicRepository.save(publicShare);
+
+        log.info("item id: {}", item.getId());
+        log.info("in public share: {}", publicShare.getItem().getId());
+
+        assertThatThrownBy(() ->
+            permissionService.validatePassword(item.getId(), "wrong-password")
+        ).isInstanceOf(ItemPasswordVerificationFailedException.class)
+            .hasMessageContaining("wrong");
+    }
+
+    /**
+     * Test for getPermission method when user has public share with null password.
+     */
+    @Test
+    void shouldPassWhenPasswordIsCorrect() {
+        FileSystemItemEntity item = createAndSaveFileItem();
+
+        String password = "valid-password";
+        String hash = new BCryptPasswordEncoder().encode(password);
+
+        SharedItemsPublicEntity publicShare = new SharedItemsPublicEntity();
+        publicShare.setItem(item);
+        publicShare.setPermission(FileSystemPermission.VIEWER);
+        publicShare.setSharedBy(item.getOwner());
+        publicShare.setPasswordHash(hash);
+        publicShare.setExpiresAt(Timestamp.from(Instant.now().plusSeconds(3600)));
+        sharedItemsPublicRepository.save(publicShare);
+
+        permissionService.validatePassword(item.getId(), password);
+    }
+
+    private FileSystemItemEntity createAndSaveFileItem() {
+        FileSystemItemEntity item = new FileSystemItemEntity();
+        item.setName("Public File");
+        item.setSize(123L);
+        item.setMimeType("text/plain");
+        item.setOwner(UUID.randomUUID());
+        item.setStatus(UploadStatus.UPLOADED);
+        item.setType(FileSystemItemType.FILE);
+        item.setS3Url("s3://test-bucket/test");
+        return fileSystemItemRepository.save(item);
+    }
+
 }


### PR DESCRIPTION
### Description

When user is trying to access an item, first if the item owner is the requested user, then (s) he can view the item. If he is not the owner, then we query the `SharedItemsPrivate` to check if the item is shared with password, if so then report back to user.

### Related Issue

closes #244 

### Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Chore (maintenance, refactoring, etc.)
- [ ] Other (please describe):

### Checklist

<!-- Please check the items that apply and make sure to complete them before submitting your PR. -->

- [x] I have tested my changes.
- [ ] I have updated the documentation (if necessary).
- [ ] I have added necessary tests (if applicable).

### Screenshots/videos (if applicable)

<!-- If your changes include visual updates, please include screenshots/gifs/videos here. -->

### Additional Context

<!-- Any other information or context that is helpful to understand your changes (e.g., implementation details, reasoning,
etc.). -->
